### PR TITLE
WP-Builder: Add support for multiline string

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -5,6 +5,7 @@ import {
 } from "@jsonforms/material-renderers";
 import { JsonForms } from "@jsonforms/react";
 import TextControl, { textControlTester } from "../renderers/TextControl";
+import MultilineTextControl, { multilineTextControlTester } from "../renderers/MultilineTextControl";
 
 const schema = {
   type: "object",
@@ -32,6 +33,9 @@ const uischema = {
     {
       type: "Control",
       scope: "#/properties/multilineTextControl",
+      options: {
+        multi: true,
+      },
     }
   ],
 };
@@ -43,6 +47,7 @@ const renderers = [
   ...materialRenderers,
   //register custom renderers
   { tester: textControlTester, renderer: TextControl },
+  { tester: multilineTextControlTester, renderer: MultilineTextControl },
 ];
 
 export default function App() {

--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -13,6 +13,11 @@ const schema = {
       type: "string",
       label: "Text Control Label",
       description: "Text Control displays a 'string' Control"
+    },
+    multilineTextControl: {
+      type: "string",
+      label: "Muliline Text Control Label",
+      description: "Multiline Text Control displays a 'string' Control supports multiline"
     }
   },
 };
@@ -23,6 +28,10 @@ const uischema = {
     {
       type: "Control",
       scope: "#/properties/textControl",
+    },
+    {
+      type: "Control",
+      scope: "#/properties/multilineTextControl",
     }
   ],
 };

--- a/src/js/renderers/MultilineTextControl.js
+++ b/src/js/renderers/MultilineTextControl.js
@@ -1,0 +1,40 @@
+import React from "react";
+import { withJsonFormsControlProps } from "@jsonforms/react";
+import { rankWith, isMultiLineControl } from "@jsonforms/core";
+import { TextareaControl } from '@wordpress/components';
+
+const TextControl = (props) => {
+  const {
+    id,
+    description,
+    errors,
+    label,
+    uischema,
+    path,
+    visible,
+    required,
+    config,
+    data,
+    input,
+    handleChange
+  } = props;
+  
+  return ( 
+    <TextareaControl
+      help={description}
+      label={label}
+      value={data || ''}
+      onChange={(value) =>
+        handleChange(path, value === '' ? undefined : value)
+      }
+      rows={4}
+    /> 
+  )
+};
+
+export const multilineTextControlTester = rankWith(
+  5, //increase rank as needed
+  isMultiLineControl
+);
+
+export default withJsonFormsControlProps(TextControl);


### PR DESCRIPTION
## Summary
- Create new TextareaControl for multiline text

## Reference
https://github.com/bangank36/WP-Builder/issues/6