### PR TITLE
WP-Builder: Feat/colorPalette-implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"@jsonforms/react": "^3.1.0",
 				"@mui/material": "^5.13.6",
 				"@wordpress/components": "^25.1.0",
+				"framer-motion": "^10.11.6",
 				"prop-types": "^15.7.2",
 				"query-string": "^7.0.1",
 				"react": "^18.2.0",
@@ -7272,9 +7273,9 @@
 			}
 		},
 		"node_modules/framer-motion": {
-			"version": "10.12.17",
-			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.17.tgz",
-			"integrity": "sha512-IR+aAYntsyu6ofyxqQV4QYotmOqzcuKxhqNpfc3DXJjNWOPpOeSyH0A+In3IEBu49Yx/+PNht+YMeZSdCNaYbw==",
+			"version": "10.11.6",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.11.6.tgz",
+			"integrity": "sha512-QXfnUzPQqbJEnWpmtPaRB4OCuyH44uCys5Agg44LEQvItKTg0bou57WuhsNVuEyVCnMoAhrtRYiKeG/vAz6bFw==",
 			"dependencies": {
 				"tslib": "^2.4.0"
 			},
@@ -18360,9 +18361,9 @@
 			}
 		},
 		"framer-motion": {
-			"version": "10.12.17",
-			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.17.tgz",
-			"integrity": "sha512-IR+aAYntsyu6ofyxqQV4QYotmOqzcuKxhqNpfc3DXJjNWOPpOeSyH0A+In3IEBu49Yx/+PNht+YMeZSdCNaYbw==",
+			"version": "10.11.6",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.11.6.tgz",
+			"integrity": "sha512-QXfnUzPQqbJEnWpmtPaRB4OCuyH44uCys5Agg44LEQvItKTg0bou57WuhsNVuEyVCnMoAhrtRYiKeG/vAz6bFw==",
 			"requires": {
 				"@emotion/is-prop-valid": "^0.8.2",
 				"tslib": "^2.4.0"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"@jsonforms/react": "^3.1.0",
 		"@mui/material": "^5.13.6",
 		"@wordpress/components": "^25.1.0",
+		"framer-motion": "^10.11.6",
 		"prop-types": "^15.7.2",
 		"query-string": "^7.0.1",
 		"react": "^18.2.0",

--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -6,6 +6,7 @@ import {
 import { JsonForms } from "@jsonforms/react";
 import TextControl, { textControlTester } from "../renderers/TextControl";
 import MultilineTextControl, { multilineTextControlTester } from "../renderers/MultilineTextControl";
+import ColorPaletteTextControl, { colorPaletteControlTester } from "../renderers/ColorPaletteControl";
 
 const schema = {
   type: "object",
@@ -19,6 +20,11 @@ const schema = {
       type: "string",
       label: "Muliline Text Control Label",
       description: "Multiline Text Control displays a 'string' Control supports multiline"
+    },
+    colorPaletteControl: {
+      type: "string",
+      label: "Color Palette Control Label",
+      description: "Color Picker with predefine palette"
     }
   },
 };
@@ -36,6 +42,27 @@ const uischema = {
       options: {
         multi: true,
       },
+    },
+    {
+      type: "Control",
+      scope: "#/properties/colorPaletteControl",
+      options: {
+        format: 'color',
+        colors:[
+          {
+            color: '#f00',
+            name: 'Red'
+          },
+          {
+            color: '#fff',
+            name: 'White'
+          },
+          {
+            color: '#00f',
+            name: 'Blue'
+          }
+        ]
+      },
     }
   ],
 };
@@ -48,6 +75,7 @@ const renderers = [
   //register custom renderers
   { tester: textControlTester, renderer: TextControl },
   { tester: multilineTextControlTester, renderer: MultilineTextControl },
+  { tester: colorPaletteControlTester, renderer: ColorPaletteTextControl },
 ];
 
 export default function App() {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -5,6 +5,9 @@ import ReactDOM from "react-dom";
 // include your styles into the webpack bundle
 import "../styles/index.css";
 
+// include @wordpress/components styles
+import '@wordpress/components/build-style/style.css';
+
 //import your own components
 import Home from "./component/form.jsx";
 

--- a/src/js/renderers/ColorPaletteControl.js
+++ b/src/js/renderers/ColorPaletteControl.js
@@ -1,0 +1,43 @@
+import React from "react";
+import { withJsonFormsControlProps } from "@jsonforms/react";
+import { rankWith, isStringControl, and, optionIs } from "@jsonforms/core";
+import { ColorPalette } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+const TextControl = (props) => {
+  const {
+    id,
+    description,
+    errors,
+    label,
+    uischema,
+    path,
+    visible,
+    required,
+    config,
+    data,
+    input,
+    handleChange
+  } = props;
+  
+  const colors = [
+    { name: 'red', color: '#f00' },
+    { name: 'white', color: '#fff' },
+    { name: 'blue', color: '#00f' },
+  ];
+
+  return ( 
+    <ColorPalette
+      colors={ colors }
+      value={ data }
+      onChange={ ( color ) => handleChange( color ) }
+    />
+  )
+};
+
+export const colorPaletteControlTester = rankWith(
+  6, //increase rank as needed
+  and(isStringControl, optionIs('format', 'color'))
+);
+
+export default withJsonFormsControlProps(TextControl);

--- a/src/js/renderers/ColorPaletteControl.js
+++ b/src/js/renderers/ColorPaletteControl.js
@@ -1,4 +1,5 @@
 import React from "react";
+import isEmpty from 'lodash/isEmpty';
 import { withJsonFormsControlProps } from "@jsonforms/react";
 import { rankWith, isStringControl, and, optionIs } from "@jsonforms/core";
 import { ColorPalette, SlotFillProvider, Popover } from '@wordpress/components';
@@ -40,9 +41,20 @@ const TextControl = (props) => {
   )
 };
 
+  const optionIsNotEmpty =
+  (optionName) =>
+  (uischema) => {
+    if (isEmpty(uischema)) {
+      return false;
+    }
+
+    const options = uischema.options;
+    return !isEmpty(options) && !isEmpty(options[optionName]);
+  };
+
 export const colorPaletteControlTester = rankWith(
   6, //increase rank as needed
-  and(isStringControl, optionIs('format', 'color'))
+  and(isStringControl, optionIs('format', 'color'), optionIsNotEmpty('colors'))
 );
 
 export default withJsonFormsControlProps(TextControl);

--- a/src/js/renderers/ColorPaletteControl.js
+++ b/src/js/renderers/ColorPaletteControl.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { withJsonFormsControlProps } from "@jsonforms/react";
 import { rankWith, isStringControl, and, optionIs } from "@jsonforms/core";
-import { ColorPalette } from '@wordpress/components';
+import { ColorPalette, SlotFillProvider, Popover } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
 const TextControl = (props) => {
@@ -27,13 +27,16 @@ const TextControl = (props) => {
   ];
 
   return ( 
-    <ColorPalette
-      colors={ colors }
-      value={ data }
-      onChange={ ( value ) => 
-        handleChange(path, value === '' ? undefined : value)
-      }
-    />
+    <SlotFillProvider>
+      <ColorPalette
+        colors={ colors }
+        value={ data }
+        onChange={ ( value ) => 
+          handleChange(path, value === '' ? undefined : value)
+        }
+      />
+      <Popover.Slot />
+    </SlotFillProvider>
   )
 };
 

--- a/src/js/renderers/ColorPaletteControl.js
+++ b/src/js/renderers/ColorPaletteControl.js
@@ -20,7 +20,7 @@ const TextControl = (props) => {
     handleChange
   } = props;
   
-  const colors = [
+  const colors = uischema.options.colors || [
     { name: 'red', color: '#f00' },
     { name: 'white', color: '#fff' },
     { name: 'blue', color: '#00f' },
@@ -30,7 +30,9 @@ const TextControl = (props) => {
     <ColorPalette
       colors={ colors }
       value={ data }
-      onChange={ ( color ) => handleChange( color ) }
+      onChange={ ( value ) => 
+        handleChange(path, value === '' ? undefined : value)
+      }
     />
   )
 };


### PR DESCRIPTION
## Summary
- Implement color pallete control with Gutenberg, { format: 'color' }
- Note that the new `optionIsNotEmpty` method should move to new file when needed, it will expect a `colors` prop in `options` object to display a regular color picker ( implemented soon ) or a palette picker

## Reference
- https://github.com/bangank36/WP-Builder/issues/8
- `Framer motion` lib makes the popover broken has been address and fixed in this issue https://togithub.com/WordPress/gutenberg/issues/51893