### PR TITLE
WP-Builder: Feat/color picker dropdown

### DIFF
--- a/src/js/renderers/ColorPaletteControl.js
+++ b/src/js/renderers/ColorPaletteControl.js
@@ -3,12 +3,9 @@ import isEmpty from 'lodash/isEmpty';
 import { withJsonFormsControlProps } from "@jsonforms/react";
 import { rankWith, isStringControl, and, optionIs } from "@jsonforms/core";
 import {
-	__experimentalToolsPanel as ToolsPanel,
-	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalHStack as HStack,
 	__experimentalZStack as ZStack,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
-	TabPanel,
 	ColorIndicator,
 	Flex,
 	FlexItem,

--- a/src/js/renderers/ColorPaletteControl.js
+++ b/src/js/renderers/ColorPaletteControl.js
@@ -59,20 +59,41 @@ const TextControl = (props) => {
 
   return ( 
     <>
-      <LabeledColorIndicators
-        indicators={ ['#ccc'] }
-        label={ label }
+      <Dropdown
+        popoverProps={ {
+          placement: 'left-start',
+          offset: 36,
+          shift: true,
+        } }
+        className="my-container-class-name"
+        contentClassName="my-dropdown-content-classname"
+        renderToggle={ ( { isOpen, onToggle } ) => (
+          <Button
+            onClick={ onToggle }
+            aria-expanded={ isOpen }
+          >
+            <LabeledColorIndicators
+              indicators={ [ data ] }
+              label={ label }
+            />
+          </Button>
+        ) }
+        renderContent={ () => (
+          <DropdownContentWrapper paddingSize="none">
+            <SlotFillProvider>
+              <ColorPalette
+                colors={ colors }
+                value={ data }
+                onChange={ ( value ) => 
+                  handleChange(path, value === '' ? undefined : value)
+                }
+              />
+              <Popover.Slot />
+            </SlotFillProvider>
+          </DropdownContentWrapper>
+        ) }
       />
-      <SlotFillProvider>
-        <ColorPalette
-          colors={ colors }
-          value={ data }
-          onChange={ ( value ) => 
-            handleChange(path, value === '' ? undefined : value)
-          }
-        />
-        <Popover.Slot />
-      </SlotFillProvider>
+      
     </>
   )
 };

--- a/src/js/renderers/ColorPaletteControl.js
+++ b/src/js/renderers/ColorPaletteControl.js
@@ -2,8 +2,38 @@ import React from "react";
 import isEmpty from 'lodash/isEmpty';
 import { withJsonFormsControlProps } from "@jsonforms/react";
 import { rankWith, isStringControl, and, optionIs } from "@jsonforms/core";
-import { ColorPalette, SlotFillProvider, Popover } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import {
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalHStack as HStack,
+	__experimentalZStack as ZStack,
+	__experimentalDropdownContentWrapper as DropdownContentWrapper,
+	TabPanel,
+	ColorIndicator,
+	Flex,
+	FlexItem,
+	Dropdown,
+	Button,
+  ColorPalette, SlotFillProvider, Popover
+} from '@wordpress/components';
+
+const LabeledColorIndicators = ( { indicators, label } ) => (
+	<HStack justify="flex-start">
+		<ZStack isLayered={ false } offset={ -8 }>
+			{ indicators.map( ( indicator, index ) => (
+				<Flex key={ index } expanded={ false }>
+					<ColorIndicator colorValue={ indicator } />
+				</Flex>
+			) ) }
+		</ZStack>
+		<FlexItem
+			className="block-editor-panel-color-gradient-settings__color-name"
+			title={ label }
+		>
+			{ label }
+		</FlexItem>
+	</HStack>
+);
 
 const TextControl = (props) => {
   const {
@@ -28,16 +58,22 @@ const TextControl = (props) => {
   ];
 
   return ( 
-    <SlotFillProvider>
-      <ColorPalette
-        colors={ colors }
-        value={ data }
-        onChange={ ( value ) => 
-          handleChange(path, value === '' ? undefined : value)
-        }
+    <>
+      <LabeledColorIndicators
+        indicators={ ['#ccc'] }
+        label={ label }
       />
-      <Popover.Slot />
-    </SlotFillProvider>
+      <SlotFillProvider>
+        <ColorPalette
+          colors={ colors }
+          value={ data }
+          onChange={ ( value ) => 
+            handleChange(path, value === '' ? undefined : value)
+          }
+        />
+        <Popover.Slot />
+      </SlotFillProvider>
+    </>
   )
 };
 


### PR DESCRIPTION
## Summary
- Improve the Color Control with Dropdown button where the color is displayed using an indicator and the whole Color Palette Control is rendered inside a Dropdown
- Screenshot 

| Palette Opened | Color Picker opened |
|---------|-------|
|    <img width="457" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/60c76ee2-7945-481b-83c1-1a07ec03e2ea">     |    <img width="467" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/354e9c4d-b9d0-4143-81d1-dac04e58ed64">   |

- Though the basic UI for Dropdown has been done, we may need to implement some custom style to let the ColorPicker to align well with the Dropdown Content, check Heading Block Inspector for example...
<img width="821" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/76c7e2a1-8a15-43b5-a4bb-e31101903801">


## Reference
#3 
#11 