### PR TITLE
WP-Builder: Feat/introduce-navigator-layout

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -9,86 +9,53 @@ import MultilineTextControl, { multilineTextControlTester } from "../renderers/M
 import ColorPaletteTextControl, { colorPaletteControlTester } from "../renderers/ColorPaletteControl";
 import BooleanToggleControl, { booleanToggleControlTester } from "../renderers/BooleanToggleControl";
 import BooleanCheckboxControl, { booleanCheckboxControlTester } from "../renderers/BooleanCheckboxControl";
+import GutenbergNavigatorlLayoutRenderer, { gutenbergNavigatorLayoutTester } from "../renderers/NavigatorLayout";
 
 const schema = {
   type: "object",
   properties: {
-    textControl: {
-      type: "string",
-      label: "Text Control Label",
-      description: "Text Control displays a 'string' Control"
+    address: {
+      type: 'object',
+      properties: {
+        street_address: { type: 'string' },
+        city: { type: 'string' },
+        state: { type: 'string' },
+        user: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            mail: { type: 'string' },
+          }
+        }
+      }
     },
-    multilineTextControl: {
-      type: "string",
-      label: "Muliline Text Control Label",
-      description: "Multiline Text Control displays a 'string' Control supports multiline"
-    },
-    colorPaletteControl: {
-      type: "string",
-      label: "Color Palette Control Label",
-      description: "Color Picker with predefine palette"
-    },
-    booleanToggleControl: {
-      type: "boolean",
-      label: "Boolean Toggle Control Label",
-      description: "Boolean Control with Toggle Renderer"
-    },
-    booleanCheckboxControl: {
-      type: "boolean",
-      label: "Boolean Checkbox Control Label",
-      description: "Boolean Control with Checkbox Renderer"
+    business: {
+      type: 'object',
+      properties: {
+        job: { type: 'string' }
+      }
     }
   },
 };
 
 const uischema = {
-  type: "VerticalLayout",
+  type: "NavigatorLayout",
   elements: [
     {
-      type: "Control",
-      scope: "#/properties/textControl",
-    },
-    {
-      type: "Control",
-      scope: "#/properties/multilineTextControl",
-      options: {
-        multi: true,
-      },
-    },
-    {
-      type: "Control",
-      scope: "#/properties/colorPaletteControl",
-      options: {
-        format: 'color',
-        colors:[
-          {
-            color: '#f00',
-            name: 'Red'
-          },
-          {
-            color: '#fff',
-            name: 'White'
-          },
-          {
-            color: '#00f',
-            name: 'Blue'
-          }
-        ]
-      },
-    },
-    {
-      type: "Control",
-      scope: "#/properties/booleanToggleControl",
-      options: {
-        toggle: true
-      }
-    },
-    {
-      type: "Control",
-      scope: "#/properties/booleanCheckboxControl",
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Control',
+          scope: '#/properties/address',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/business',
+        }
+      ],
     }
   ],
-};
+}
 
 const initialData = {};
 
@@ -100,7 +67,8 @@ const renderers = [
   { tester: multilineTextControlTester, renderer: MultilineTextControl },
   { tester: colorPaletteControlTester, renderer: ColorPaletteTextControl },
   { tester: booleanToggleControlTester, renderer: BooleanToggleControl},
-  { tester: booleanCheckboxControlTester, renderer: BooleanCheckboxControl}
+  { tester: booleanCheckboxControlTester, renderer: BooleanCheckboxControl},
+  { tester: gutenbergNavigatorLayoutTester, renderer: GutenbergNavigatorlLayoutRenderer}
 ];
 
 export default function App() {

--- a/src/js/renderers/NavigatorLayout.js
+++ b/src/js/renderers/NavigatorLayout.js
@@ -57,7 +57,6 @@ export const GutenbergNavigatorlLayoutRenderer = ({
     };
 
     const navigatableProps = getObjectProperties(schema.properties);
-    console.log(navigatableProps);
 
     // The navigatorLayout should be the root layout
     const navigatorLayout = uischema

--- a/src/js/renderers/NavigatorLayout.js
+++ b/src/js/renderers/NavigatorLayout.js
@@ -81,7 +81,7 @@ export const GutenbergNavigatorlLayoutRenderer = ({
         <NavigatorProvider initialPath="/">
             <NavigatorScreen path="/">
                 <p>This is the home screen.</p>
-                {navigatableProps.map(({path, key, dotPath}, index) => (
+                {navigatableProps.filter((({dotPath}) => dotPath.split(".").length < 2 )).map(({path, key, dotPath}, index) => (
                     <NavigatorButton path={`${path}`}>
                         <p>Go to <strong>{key}</strong> screen. {dotPath}</p>
                     </NavigatorButton>

--- a/src/js/renderers/NavigatorLayout.js
+++ b/src/js/renderers/NavigatorLayout.js
@@ -1,0 +1,81 @@
+import React from "react"
+import { rankWith, uiTypeIs } from "@jsonforms/core"
+import { MaterialLayoutRenderer } from "./NavigatorRenderer"
+import { withJsonFormsLayoutProps } from "@jsonforms/react"
+
+import {
+    __experimentalNavigatorProvider as NavigatorProvider,
+    __experimentalNavigatorScreen as NavigatorScreen,
+    __experimentalNavigatorButton as NavigatorButton,
+    __experimentalNavigatorToParentButton as NavigatorToParentButton,
+} from '@wordpress/components';
+
+/**
+ * Default tester for a vertical layout.
+ * @type {RankedTester}
+ */
+export const gutenbergNavigatorLayoutTester = rankWith(
+  2,
+  uiTypeIs("NavigatorLayout")
+)
+
+export const GutenbergNavigatorlLayoutRenderer = ({
+  uischema,
+  schema,
+  path,
+  enabled,
+  visible,
+  renderers,
+  cells
+}) => {
+
+    // Hard code: grab all `object` type properties
+    const propertiesArr = Object.keys(schema.properties);
+    propertiesArr.filter((key) => {
+        return schema.properties[key]?.type === 'object'
+    });
+
+    
+    const verticalLayout = uischema
+
+    const childProps = {
+        elements: verticalLayout.elements,
+        schema,
+        path,
+        enabled,
+        direction: "column",
+        visible
+    }
+
+  return (
+    <>
+        <NavigatorProvider initialPath="/">
+            <NavigatorScreen path="/">
+            <p>This is the home screen.</p>
+            {propertiesArr.map((propKey, index) => (
+                <NavigatorButton path={`/${propKey}`}>
+                    <p>Go to <strong>{propKey}</strong> screen.</p>
+                </NavigatorButton>
+            ))}
+            <MaterialLayoutRenderer
+                {...childProps}
+                renderers={renderers}
+                cells={cells}
+            />
+            </NavigatorScreen>
+
+            {propertiesArr.map((propKey, index) => (
+                <NavigatorScreen path={`/${propKey}`}>
+                    <p>This is the <strong>{propKey}</strong> screen.</p>
+                    <NavigatorToParentButton>
+                        Go back
+                    </NavigatorToParentButton>
+                </NavigatorScreen>
+            ))}
+        
+        </NavigatorProvider>
+    </>
+  )
+}
+
+export default withJsonFormsLayoutProps(GutenbergNavigatorlLayoutRenderer)

--- a/src/js/renderers/NavigatorRenderer.js
+++ b/src/js/renderers/NavigatorRenderer.js
@@ -1,0 +1,74 @@
+import isEmpty from "lodash/isEmpty"
+import React from "react"
+import { getAjv } from "@jsonforms/core"
+import { JsonFormsDispatch, useJsonForms } from "@jsonforms/react"
+import { Grid, Hidden } from "@mui/material"
+
+export const renderLayoutElements = (
+  elements,
+  schema,
+  path,
+  enabled,
+  renderers,
+  cells
+) => {
+  return elements.map((child, index) => (
+    <Grid item key={`${path}-${index}`} xs>
+      <JsonFormsDispatch
+        uischema={child}
+        schema={schema}
+        path={path}
+        enabled={enabled}
+        renderers={renderers}
+        cells={cells}
+      />
+    </Grid>
+  ))
+}
+
+const MaterialLayoutRendererComponent = ({
+  visible,
+  elements,
+  schema,
+  path,
+  enabled,
+  direction,
+  renderers,
+  cells
+}) => {
+  if (isEmpty(elements)) {
+    return null
+  } else {
+    return (
+      <Hidden xsUp={!visible}>
+        <Grid
+          container
+          direction={direction}
+          spacing={direction === "row" ? 2 : 0}
+        >
+          {renderLayoutElements(
+            elements,
+            schema,
+            path,
+            enabled,
+            renderers,
+            cells
+          )}
+        </Grid>
+      </Hidden>
+    )
+  }
+}
+export const MaterialLayoutRenderer = React.memo(
+  MaterialLayoutRendererComponent
+)
+
+// TODO fix @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/ban-types
+export const withAjvProps = Component =>
+  function WithAjvProps(props) {
+    const ctx = useJsonForms()
+    const ajv = getAjv({ jsonforms: { ...ctx } })
+
+    return <Component {...props} ajv={ajv} />
+  }


### PR DESCRIPTION
## Summary
Addressed the new layout renderer `NavigatorLayout`, we had achieved some thing as followed
- With the help of new util method `getObjectProperties`, we can extract all the nested object properties into an array and use it to render **ALL** `NavigatorScreen` at first run
- The recording also addressed these issues which can be solved by follow ups
  - The mismatch generated data (Not visible on screen) https://github.com/bangank36/WP-Builder/issues/21
  - `business` screen is a loop hole, because I am hard coded the `elements` of [the NavigatorLayout](https://github.com/bangank36/WP-Builder/pull/20/files#diff-6c3491535c8451e0fa71ccdc883e19cf9c4e82ecef5ae57cb60c6320dfb2e11fR100), we should filter the 1st level properties better
![chrome-capture-2023-6-6](https://github.com/bangank36/WP-Builder/assets/10071857/27cb5835-6cf4-4773-a566-3c01958469bb)

## Reference
https://github.com/bangank36/WP-Builder/issues/19