### PR TITLE
WP-Builder: Insert new object renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@jsonforms/core": "^3.1.0",
 				"@jsonforms/material-renderers": "^3.1.0",
 				"@jsonforms/react": "^3.1.0",
+				"@jsonforms/vanilla-renderers": "^3.1.0",
 				"@mui/material": "^5.13.6",
 				"@wordpress/components": "^25.1.0",
 				"framer-motion": "^10.11.6",
@@ -2085,6 +2086,16 @@
 			},
 			"peerDependencies": {
 				"@jsonforms/core": "3.1.0",
+				"react": "^16.12.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/@jsonforms/vanilla-renderers": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@jsonforms/vanilla-renderers/-/vanilla-renderers-3.1.0.tgz",
+			"integrity": "sha512-hUjHPfNdA/UQhmBrNtlXCU7nWYu+9RCKm0gTG4gt8D7sh/boXDpibdy8Y918zpduif5ZCQsO8TeEQJ5Wv/m7qQ==",
+			"peerDependencies": {
+				"@jsonforms/core": "3.1.0",
+				"@jsonforms/react": "3.1.0",
 				"react": "^16.12.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
@@ -14474,6 +14485,12 @@
 			"requires": {
 				"lodash": "^4.17.15"
 			}
+		},
+		"@jsonforms/vanilla-renderers": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@jsonforms/vanilla-renderers/-/vanilla-renderers-3.1.0.tgz",
+			"integrity": "sha512-hUjHPfNdA/UQhmBrNtlXCU7nWYu+9RCKm0gTG4gt8D7sh/boXDpibdy8Y918zpduif5ZCQsO8TeEQJ5Wv/m7qQ==",
+			"requires": {}
 		},
 		"@mui/base": {
 			"version": "5.0.0-beta.5",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"@jsonforms/core": "^3.1.0",
 		"@jsonforms/material-renderers": "^3.1.0",
 		"@jsonforms/react": "^3.1.0",
+		"@jsonforms/vanilla-renderers": "^3.1.0",
 		"@mui/material": "^5.13.6",
 		"@wordpress/components": "^25.1.0",
 		"framer-motion": "^10.11.6",

--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -1,14 +1,15 @@
 import React, { useState } from "react";
 import {
-  materialRenderers,
-  materialCells,
-} from "@jsonforms/material-renderers";
+  vanillaRenderers as materialRenderers,
+  vanillaCells as materialCells,
+} from "@jsonforms/vanilla-renderers";
 import { JsonForms } from "@jsonforms/react";
 import TextControl, { textControlTester } from "../renderers/TextControl";
 import MultilineTextControl, { multilineTextControlTester } from "../renderers/MultilineTextControl";
 import ColorPaletteTextControl, { colorPaletteControlTester } from "../renderers/ColorPaletteControl";
 import BooleanToggleControl, { booleanToggleControlTester } from "../renderers/BooleanToggleControl";
 import BooleanCheckboxControl, { booleanCheckboxControlTester } from "../renderers/BooleanCheckboxControl";
+import GutenbergObjectRenderer, { gutenbergObjectControlTester } from "../renderers/ObjectRenderer";
 import GutenbergNavigatorlLayoutRenderer, { gutenbergNavigatorLayoutTester } from "../renderers/NavigatorLayout";
 
 const schema = {
@@ -68,6 +69,7 @@ const renderers = [
   { tester: colorPaletteControlTester, renderer: ColorPaletteTextControl },
   { tester: booleanToggleControlTester, renderer: BooleanToggleControl},
   { tester: booleanCheckboxControlTester, renderer: BooleanCheckboxControl},
+  { tester: gutenbergObjectControlTester, renderer: GutenbergObjectRenderer},
   { tester: gutenbergNavigatorLayoutTester, renderer: GutenbergNavigatorlLayoutRenderer}
 ];
 

--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -12,6 +12,10 @@ import BooleanCheckboxControl, { booleanCheckboxControlTester } from "../rendere
 import GutenbergObjectRenderer, { gutenbergObjectControlTester } from "../renderers/ObjectRenderer";
 import GutenbergNavigatorlLayoutRenderer, { gutenbergNavigatorLayoutTester } from "../renderers/NavigatorLayout";
 
+import {
+  __experimentalGrid as Grid,
+} from '@wordpress/components';
+
 const schema = {
   type: "object",
   properties: {
@@ -76,16 +80,27 @@ const renderers = [
 export default function App() {
   const [data, setData] = useState(initialData);
   return (
-    <JsonForms
-      schema={schema}
-      uischema={uischema}
-      data={data}
-      renderers={renderers}
-      cells={materialCells}
-      onChange={({ data, _errors }) => {
-        console.log(data);
-        setData(data);
-      }}
-    />
+    <>
+      <Grid columns={ 3 }>
+        <JsonForms
+          schema={schema}
+          uischema={uischema}
+          data={data}
+          renderers={renderers}
+          cells={materialCells}
+          onChange={({ data, _errors }) => {
+            console.log(data);
+            setData(data);
+          }}
+        />
+        <div>
+          <pre>
+          {JSON.stringify(data, null, 4)}
+          </pre>
+        </div>
+      </Grid>
+      
+    </>
+    
   );
 }

--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -25,11 +25,10 @@ const schema = {
         street_address: { type: 'string' },
         city: { type: 'string' },
         state: { type: 'string' },
-        user: {
+        country: {
           type: 'object',
           properties: {
             name: { type: 'string' },
-            mail: { type: 'string' },
           }
         }
       }

--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -98,8 +98,6 @@ export default function App() {
           </pre>
         </div>
       </Grid>
-      
     </>
-    
   );
 }

--- a/src/js/renderers/NavigatorLayout.js
+++ b/src/js/renderers/NavigatorLayout.js
@@ -1,10 +1,13 @@
 import React from "react"
-import { rankWith, uiTypeIs } from "@jsonforms/core"
-import { MaterialLayoutRenderer } from "./NavigatorRenderer"
+import isEmpty from 'lodash/isEmpty';
+import { rankWith, uiTypeIs, findUISchema, Generate } from "@jsonforms/core"
+// import { MaterialLayoutRenderer } from "./NavigatorRenderer"
 import { 
     JsonFormsDispatch,
     withJsonFormsLayoutProps 
 } from "@jsonforms/react"
+
+import { Grid, Hidden } from "@mui/material"
 
 import {
     __experimentalNavigatorProvider as NavigatorProvider,
@@ -20,6 +23,65 @@ import {
 export const gutenbergNavigatorLayoutTester = rankWith(
   2,
   uiTypeIs("NavigatorLayout")
+)
+
+export const renderLayoutElements = (
+  elements,
+  schema,
+  path,
+  enabled,
+  renderers,
+  cells
+) => {
+  return elements.map((child, index) => (
+    <Grid item key={`${path}-${index}`} xs>
+      <JsonFormsDispatch
+        uischema={child}
+        schema={schema}
+        path={path}
+        enabled={enabled}
+        renderers={renderers}
+        cells={cells}
+      />
+    </Grid>
+  ))
+}
+
+const MaterialLayoutRendererComponent = ({
+  visible,
+  elements,
+  schema,
+  path,
+  enabled,
+  direction,
+  renderers,
+  cells
+}) => {
+  if (isEmpty(elements)) {
+    return null
+  } else {
+    return (
+      <Hidden xsUp={!visible}>
+        <Grid
+          container
+          direction={direction}
+          spacing={direction === "row" ? 2 : 0}
+        >
+          {renderLayoutElements(
+            elements,
+            schema,
+            path,
+            enabled,
+            renderers,
+            cells
+          )}
+        </Grid>
+      </Hidden>
+    )
+  }
+}
+export const MaterialLayoutRenderer = React.memo(
+  MaterialLayoutRendererComponent
 )
 
 export const GutenbergNavigatorlLayoutRenderer = ({
@@ -48,7 +110,7 @@ export const GutenbergNavigatorlLayoutRenderer = ({
       
             if (prop.type === 'object') {
               result.push({ path, key, dotPath });
-              result.push(...getObjectProperties(prop.properties, path));
+              // result.push(...getObjectProperties(prop.properties, path));
             }
           }
         }
@@ -88,23 +150,23 @@ export const GutenbergNavigatorlLayoutRenderer = ({
             </NavigatorScreen>
 
             {navigatableProps.map(({path, key, dotPath}, index) => (
-                <NavigatorScreen path={`${path}`}>
-                    <p>This is the <strong>{key}</strong> screen. {dotPath}</p>
-                    <NavigatorToParentButton>
-                        Go back
-                    </NavigatorToParentButton>
-                    <NavigatorButton path="/">
-                        <p>Go to home</p>
-                    </NavigatorButton>
+                    <NavigatorScreen path={`${path}`}>
+                        <p>This is the <strong>{key}</strong> screen. {dotPath}</p>
+                        <NavigatorToParentButton>
+                            Go back
+                        </NavigatorToParentButton>
+                        <NavigatorButton path="/">
+                            <p>Go to home</p>
+                        </NavigatorButton>
                     <JsonFormsDispatch
                         uischema={navigatorLayout.elements[0].elements[index]}
                         schema={schema}
                         path={dotPath}
                         enabled={enabled}
-                        renderers={renderers}
-                        cells={cells}
-                    />
-                </NavigatorScreen>
+                            renderers={renderers}
+                            cells={cells}
+                        />
+                    </NavigatorScreen>
             ))}
         
         </NavigatorProvider>

--- a/src/js/renderers/NavigatorLayout.js
+++ b/src/js/renderers/NavigatorLayout.js
@@ -110,7 +110,7 @@ export const GutenbergNavigatorlLayoutRenderer = ({
       
             if (prop.type === 'object') {
               result.push({ path, key, dotPath });
-              // result.push(...getObjectProperties(prop.properties, path));
+              result.push(...getObjectProperties(prop.properties, path));
             }
           }
         }
@@ -142,11 +142,11 @@ export const GutenbergNavigatorlLayoutRenderer = ({
         <NavigatorProvider initialPath="/">
             <NavigatorScreen path="/">
                 <p>This is the home screen.</p>
-                {navigatableProps.filter((({dotPath}) => dotPath.split(".").length < 2 )).map(({path, key, dotPath}, index) => (
-                    <NavigatorButton path={`${path}`}>
-                        <p>Go to <strong>{key}</strong> screen. {dotPath}</p>
-                    </NavigatorButton>
-                ))}
+                <MaterialLayoutRenderer
+                  {...childProps}
+                  renderers={renderers}
+                  cells={cells}
+                />
             </NavigatorScreen>
 
             {navigatableProps.map(({path, key, dotPath}, index) => (
@@ -158,13 +158,13 @@ export const GutenbergNavigatorlLayoutRenderer = ({
                         <NavigatorButton path="/">
                             <p>Go to home</p>
                         </NavigatorButton>
-                    <JsonFormsDispatch
-                        uischema={navigatorLayout.elements[0].elements[index]}
-                        schema={schema}
-                        path={dotPath}
-                        enabled={enabled}
-                            renderers={renderers}
-                            cells={cells}
+                        <JsonFormsDispatch
+                          uischema={navigatorLayout.elements[0].elements[index]}
+                          schema={schema}
+                          path={dotPath}
+                          enabled={enabled}
+                              renderers={renderers}
+                              cells={cells}
                         />
                     </NavigatorScreen>
             ))}

--- a/src/js/renderers/ObjectRenderer.js
+++ b/src/js/renderers/ObjectRenderer.js
@@ -50,24 +50,25 @@ export const GutenbergObjectRenderer = ({
     [uischemas, schema, uischema.scope, path, label, uischema, rootSchema]
   );
 
-  // Extract object prop 
-  const userProp = detailUiSchema.label === 'Country' ? true : false;
+  // Util to convert dot path into slash path: eg: address.country -> /address/country
+  const slashPath = '/' + path.split('.').join('/');
 
   return (
     <Hidden xsUp={!visible}>
-      {!userProp ? (<JsonFormsDispatch
-        visible={visible}
-        enabled={enabled}
-        schema={schema}
-        uischema={detailUiSchema}
-        path={path}
-        renderers={renderers}
-        cells={cells}
-      />) : (
-        <NavigatorButton path='/address/user'>
-          Go to User
+      <>
+        <NavigatorButton path={slashPath}>
+          Go to {detailUiSchema.label} {path}
         </NavigatorButton>
-      )}
+        <JsonFormsDispatch
+          visible={visible}
+          enabled={enabled}
+          schema={schema}
+          uischema={detailUiSchema}
+          path={path}
+          renderers={renderers}
+          cells={cells}
+        />
+      </>
     </Hidden>
   );
 };

--- a/src/js/renderers/ObjectRenderer.js
+++ b/src/js/renderers/ObjectRenderer.js
@@ -51,7 +51,7 @@ export const GutenbergObjectRenderer = ({
   );
 
   // Extract object prop 
-  const userProp = detailUiSchema.label === 'User' ? true : false;
+  const userProp = detailUiSchema.label === 'Country' ? true : false;
 
   return (
     <Hidden xsUp={!visible}>

--- a/src/js/renderers/ObjectRenderer.js
+++ b/src/js/renderers/ObjectRenderer.js
@@ -1,0 +1,73 @@
+import isEmpty from 'lodash/isEmpty';
+import {
+  findUISchema,
+  Generate,
+  isObjectControl,
+  RankedTester,
+  rankWith,
+  StatePropsOfControlWithDetail,
+} from '@jsonforms/core';
+import { 
+  JsonFormsDispatch, 
+  withJsonFormsDetailProps,
+ } from '@jsonforms/react';
+import { Hidden } from '@mui/material';
+import React, { useMemo } from 'react';
+
+import {
+  __experimentalNavigatorProvider as NavigatorProvider,
+  __experimentalNavigatorScreen as NavigatorScreen,
+  __experimentalNavigatorButton as NavigatorButton,
+  __experimentalNavigatorToParentButton as NavigatorToParentButton,
+} from '@wordpress/components';
+
+export const GutenbergObjectRenderer = ({
+  renderers,
+  cells,
+  uischemas,
+  schema,
+  label,
+  path,
+  visible,
+  enabled,
+  uischema,
+  rootSchema,
+}) => {
+  const detailUiSchema = useMemo(
+    () =>
+      findUISchema(
+        uischemas,
+        schema,
+        uischema.scope,
+        path,
+        () =>
+          isEmpty(path)
+            ? Generate.uiSchema(schema, 'VerticalLayout')
+            : { ...Generate.uiSchema(schema, 'Group'), label },
+        uischema,
+        rootSchema
+      ),
+    [uischemas, schema, uischema.scope, path, label, uischema, rootSchema]
+  );
+
+  return (
+    <Hidden xsUp={!visible}>
+      <JsonFormsDispatch
+        visible={visible}
+        enabled={enabled}
+        schema={schema}
+        uischema={detailUiSchema}
+        path={path}
+        renderers={renderers}
+        cells={cells}
+      />
+    </Hidden>
+  );
+};
+
+export const gutenbergObjectControlTester = rankWith(
+  9,
+  isObjectControl
+);
+
+export default withJsonFormsDetailProps(GutenbergObjectRenderer);

--- a/src/js/renderers/ObjectRenderer.js
+++ b/src/js/renderers/ObjectRenderer.js
@@ -50,9 +50,12 @@ export const GutenbergObjectRenderer = ({
     [uischemas, schema, uischema.scope, path, label, uischema, rootSchema]
   );
 
+  // Extract object prop 
+  const userProp = detailUiSchema.label === 'User' ? true : false;
+
   return (
     <Hidden xsUp={!visible}>
-      <JsonFormsDispatch
+      {!userProp ? (<JsonFormsDispatch
         visible={visible}
         enabled={enabled}
         schema={schema}
@@ -60,7 +63,11 @@ export const GutenbergObjectRenderer = ({
         path={path}
         renderers={renderers}
         cells={cells}
-      />
+      />) : (
+        <NavigatorButton path='/address/user'>
+          Go to User
+        </NavigatorButton>
+      )}
     </Hidden>
   );
 };


### PR DESCRIPTION
## Summary
- Create new ObjectRenderer which can filter its nested prop and only render the `NavigatorButton`, other primitive props can be rendered normally
- We should answer the **question**: how to determine wether a prop is `object`? - We don't need to, let the jsonforms to iterate over its nested object, for now we only render a `NavigatorButton`. 
- Find the current result in the recording
![chrome-capture-2023-6-8 (1)](https://github.com/bangank36/WP-Builder/assets/10071857/50decaa2-da03-487b-88c6-f7f8f48a4812)

## Reference
https://github.com/bangank36/WP-Builder/issues/22