### PR TITLE
WP-Builder: Feat/nested rendererer context

### DIFF
--- a/src/js/component/context.jsx
+++ b/src/js/component/context.jsx
@@ -1,0 +1,3 @@
+import { createContext } from 'react'
+
+export const Context = createContext()

--- a/src/js/renderers/ObjectRenderer.js
+++ b/src/js/renderers/ObjectRenderer.js
@@ -56,11 +56,11 @@ export const GutenbergObjectRenderer = ({
 
   const [screenContent, setScreenContent] = useContext(NavigatorContext);
 
-
   //UseEffect to fix the issue Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate.
   useEffect(() => {
-    setScreenContent({
-      ...screenContent,
+    // Use the callback since the new state is based on the previous state
+    setScreenContent(prevScreenContent => ({
+      ...prevScreenContent,
       [route]: {
         component: (<JsonFormsDispatch
           visible={visible}
@@ -74,7 +74,7 @@ export const GutenbergObjectRenderer = ({
         label: detailUiSchema.label,
         path: path
       }
-    })
+    }))
   }, [route])
 
   return (

--- a/src/js/renderers/ObjectRenderer.js
+++ b/src/js/renderers/ObjectRenderer.js
@@ -12,7 +12,8 @@ import {
   withJsonFormsDetailProps,
  } from '@jsonforms/react';
 import { Hidden } from '@mui/material';
-import React, { useMemo } from 'react';
+import React, { useMemo, useContext, useEffect } from 'react';
+import { Context as NavigatorContext } from '../component/context'
 
 import {
   __experimentalNavigatorProvider as NavigatorProvider,
@@ -51,12 +52,35 @@ export const GutenbergObjectRenderer = ({
   );
 
   // Util to convert dot path into slash path: eg: address.country -> /address/country
-  const slashPath = '/' + path.split('.').join('/');
+  const route = '/' + path.split('.').join('/');
+
+  const [screenContent, setScreenContent] = useContext(NavigatorContext);
+
+
+  //UseEffect to fix the issue Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate.
+  useEffect(() => {
+    setScreenContent({
+      ...screenContent,
+      [route]: {
+        component: (<JsonFormsDispatch
+          visible={visible}
+          enabled={enabled}
+          schema={schema}
+          uischema={detailUiSchema}
+          path={path}
+          renderers={renderers}
+          cells={cells}
+        />),
+        label: detailUiSchema.label,
+        path: path
+      }
+    })
+  }, [route])
 
   return (
     <Hidden xsUp={!visible}>
       <>
-        <NavigatorButton path={slashPath}>
+        <NavigatorButton path={route}>
           Go to {detailUiSchema.label} {path}
         </NavigatorButton>
         <JsonFormsDispatch


### PR DESCRIPTION
## Summary
- Implement additional context to pass the generated `JsonFormDispatch` on the nested children along with the path
- Some notes about terminology: 
   - route: used for NavigatorScreen `path` prop
   - path: used for jsonform `path` prop

- Recording 
![chrome-capture-2023-6-9 (1)](https://github.com/bangank36/WP-Builder/assets/10071857/97118026-a8bf-4680-8ed2-3d6bdf61852f)

## Reference
https://github.com/bangank36/WP-Builder/issues/26