### PR TITLE
WP-Builder: Remove object fields render

### DIFF
--- a/src/js/renderers/ObjectRenderer.js
+++ b/src/js/renderers/ObjectRenderer.js
@@ -83,15 +83,6 @@ export const GutenbergObjectRenderer = ({
         <NavigatorButton path={route}>
           Go to {detailUiSchema.label} {path}
         </NavigatorButton>
-        <JsonFormsDispatch
-          visible={visible}
-          enabled={enabled}
-          schema={schema}
-          uischema={detailUiSchema}
-          path={path}
-          renderers={renderers}
-          cells={cells}
-        />
       </>
     </Hidden>
   );


### PR DESCRIPTION
## Summary
- For this PR, we remove the fields render in Object and leave it to the NavigatorScreen
- The `disclosure` screens now display as expected
![chrome-capture-2023-6-9 (2)](https://github.com/bangank36/WP-Builder/assets/10071857/930c565d-3074-418e-bfbe-19a5f0b89cdb)


## Reference
https://github.com/bangank36/WP-Builder/issues/28