### PR TITLE
POC: Update navigator layout 

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import {
-  vanillaRenderers as materialRenderers,
-  vanillaCells as materialCells,
-} from "@jsonforms/vanilla-renderers";
+  materialRenderers,
+  materialCells,
+} from "@jsonforms/material-renderers";
 import { JsonForms } from "@jsonforms/react";
 import TextControl, { textControlTester } from "../renderers/Primitive/TextControl";
 import MultilineTextControl, { multilineTextControlTester } from "../renderers/Primitive/MultilineTextControl";
@@ -32,19 +32,7 @@ const schema = {
           properties: {
             name: { type: 'string' },
           }
-        },
-        comments: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              comment: { 
-                type: 'string',
-              },
-            }
-            
-          },
-        },
+        }
       }
     },
     business: {
@@ -94,7 +82,7 @@ const renderers = [
   { tester: colorPaletteControlTester, renderer: ColorPaletteTextControl },
   { tester: booleanToggleControlTester, renderer: BooleanToggleControl},
   { tester: booleanCheckboxControlTester, renderer: BooleanCheckboxControl},
-  { tester: gutenbergObjectControlTester, renderer: GutenbergObjectRenderer},
+  // { tester: gutenbergObjectControlTester, renderer: GutenbergObjectRenderer},
   { tester: gutenbergArrayControlTester, renderer: GutenbergArrayRenderer},
   // { tester: portedArrayControlTester, renderer: PortedArrayRenderer},
   { tester: gutenbergNavigatorLayoutTester, renderer: GutenbergNavigatorlLayoutRenderer}


### PR DESCRIPTION
## Summary
- Follow up the discussion on https://jsonforms.discourse.group/t/render-nested-forms-in-flat-structure/1591, this PR implemented the suggested solution to render the Navigator Layout with nested props
- Schema of the form can be[ found here ](https://github.com/bangank36/WP-Builder/issues/25#issuecomment-1626718027)
- To test this branch
    1. Checkout the branch
    2. Run `npm run start`
    3. Access the test site at: `localhost:3000`

## Result
- The layout can be rendered into 3 `NavigatorScreen`, but then it can not access the nested prop inside `/address`, eg: `/address/country`
- Please check the generated screens in the table below

| Main |  address | business  |
|-------|---|---|
|   <img width="335" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/a5d3f1a7-af6d-4759-92f6-e3d461743674">    |  <img width="350" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/3e9dd56b-a251-46e4-ae8a-bfbec4c919ab"> |  <img width="348" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/bc4d5549-a712-49a6-ae24-e9580e1acfed">  |

- While the suggested solution is useful for 01 nested level, the 2nd level will still be displayed on the same form layout

## Expected
- Let's compare the default layout with the Navigator layout, in the Navigator, it is expected that every deep nested level is displayed on its own screen, and the hierarchy is determined by the `path` prop, eg: `/address/country`
![Nội dung đoạn văn bản của bạn](https://github.com/bangank36/WP-Builder/assets/10071857/df821257-f4fc-4add-a993-90fc4976befa)
- This is something achieves in current state of the project (`main` branch)
![chrome-capture-2023-6-11](https://github.com/bangank36/WP-Builder/assets/10071857/c0674e5b-3ce2-46dd-ae6d-e188e9c42018)

## Reference
https://github.com/bangank36/WP-Builder/issues/35