### PR TITLE
WP-Builder: Feat/update boolean toggle style

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -27,6 +27,10 @@ const schema = {
         street_address: { type: 'string' },
         city: { type: 'string' },
         state: { type: 'string' },
+        isOffice: { 
+          type: 'boolean',
+          description: 'Is this an office address?',
+        },
         country: {
           type: 'object',
           properties: {
@@ -77,6 +81,7 @@ const uischema = {
 
 const initialData = {
   address: {
+    isOffice: false,
     comments: [{
       comment: 'test'
     },{

--- a/src/js/renderers/NavigatorLayout.js
+++ b/src/js/renderers/NavigatorLayout.js
@@ -57,12 +57,12 @@ const MemoizedChildComponent = (({ component, label, path } ) => {
                             aria-label={label}
                         >
                             <HStack justify="space-between">
-                            <FlexItem>
-                                item #{index}
-                            </FlexItem>
-                            <IconWithCurrentColor
-                                icon={isRTL() ? chevronLeft : chevronRight}
-                            />
+                                <FlexItem>
+                                    item #{index}
+                                </FlexItem>
+                                <IconWithCurrentColor
+                                    icon={isRTL() ? chevronLeft : chevronRight}
+                                />
                             </HStack>
                         </NavigationButtonAsItem>
                     )

--- a/src/js/renderers/Primitive/BooleanCheckboxControl.js
+++ b/src/js/renderers/Primitive/BooleanCheckboxControl.js
@@ -4,36 +4,36 @@ import { rankWith, isBooleanControl, optionIs, and } from "@jsonforms/core";
 import { CheckboxControl as UiCheckboxControl } from '@wordpress/components';
 
 const CheckboxControl = (props) => {
-  const {
-    id,
-    description,
-    errors,
-    label,
-    uischema,
-    path,
-    visible,
-    required,
-    config,
-    data,
-    input,
-    handleChange
-  } = props;
+  	const {
+		id,
+		description,
+		errors,
+		label,
+		uischema,
+		path,
+		visible,
+		required,
+		config,
+		data,
+		input,
+		handleChange
+  	} = props;
   
-  return ( 
-    <UiCheckboxControl
-        checked={ !!data }
-        help={description}
-        label={label}
-        onChange={(value) =>
-            handleChange(path, value === '' ? undefined : value)
-        }
-    />
-  )
+  	return ( 
+		<UiCheckboxControl
+			checked={ !!data }
+			help={description}
+			label={label}
+			onChange={(value) =>
+				handleChange(path, value === '' ? undefined : value)
+			}
+		/>
+  	)
 };
 
 export const booleanCheckboxControlTester = rankWith(
-  4, //increase rank as needed
-  isBooleanControl
+	5, //increase rank as needed
+	and(isBooleanControl, optionIs('toggle', false))
 );
 
 export default withJsonFormsControlProps(CheckboxControl);

--- a/src/js/renderers/Primitive/BooleanToggleControl.js
+++ b/src/js/renderers/Primitive/BooleanToggleControl.js
@@ -1,39 +1,60 @@
 import React from "react";
 import { withJsonFormsControlProps } from "@jsonforms/react";
 import { rankWith, isBooleanControl } from "@jsonforms/core";
-import { ToggleControl as UiToggleControl } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalSpacer as Spacer,
+	FormToggle,
+	Tooltip,	
+    FlexItem,
+	HorizontalRule
+} from '@wordpress/components';
 
 const ToggleControl = (props) => {
   	const {
 		id,
 		description,
-		errors,
 		label,
-		uischema,
 		path,
-		visible,
-		required,
-		config,
 		data,
-		input,
 		handleChange
 	} = props;
   
-  return ( 
-    <UiToggleControl
-        checked={ !!data }
-        help={description}
-        label={label}
-        onChange={(value) =>
-            handleChange(path, value === '' ? undefined : value)
-        }
-    />
-  )
+  	return ( 
+		<>
+			<HStack justify="space-between">
+				<FlexItem>
+				{ description ? (
+					<Tooltip text={ description }>
+					<label htmlFor={ id }>
+						{ label }
+					</label>
+				</Tooltip>
+				) : ( 
+					<label htmlFor={ id }>
+						{ label }
+					</label> 
+				) }
+				</FlexItem>
+				<FlexItem>
+					<FormToggle
+						checked={ !!data }
+						onChange={(event) =>
+							handleChange(path, event.target.checked || false)
+						}
+					/>
+				</FlexItem>
+			</HStack>
+			<Spacer marginTop={2} marginBottom={0}>
+				<HorizontalRule />
+			</Spacer>
+		</>
+  	)
 };
 
 export const booleanToggleControlTester = rankWith(
-  4, //increase rank as needed
-  isBooleanControl
+	4, //increase rank as needed
+	isBooleanControl
 );
 
 export default withJsonFormsControlProps(ToggleControl);

--- a/src/js/renderers/Primitive/BooleanToggleControl.js
+++ b/src/js/renderers/Primitive/BooleanToggleControl.js
@@ -1,23 +1,23 @@
 import React from "react";
 import { withJsonFormsControlProps } from "@jsonforms/react";
-import { rankWith, isBooleanControl, optionIs, and } from "@jsonforms/core";
+import { rankWith, isBooleanControl } from "@jsonforms/core";
 import { ToggleControl as UiToggleControl } from '@wordpress/components';
 
 const ToggleControl = (props) => {
-  const {
-    id,
-    description,
-    errors,
-    label,
-    uischema,
-    path,
-    visible,
-    required,
-    config,
-    data,
-    input,
-    handleChange
-  } = props;
+  	const {
+		id,
+		description,
+		errors,
+		label,
+		uischema,
+		path,
+		visible,
+		required,
+		config,
+		data,
+		input,
+		handleChange
+	} = props;
   
   return ( 
     <UiToggleControl
@@ -32,8 +32,8 @@ const ToggleControl = (props) => {
 };
 
 export const booleanToggleControlTester = rankWith(
-  5, //increase rank as needed
-  and(isBooleanControl, optionIs('toggle', true))
+  4, //increase rank as needed
+  isBooleanControl
 );
 
 export default withJsonFormsControlProps(ToggleControl);


### PR DESCRIPTION
## Summary
- This PR apply some changes to the boolean control
1. Favor toggle control over checkbox
2. Update UI of Toggle with `HStack` and `Tooltip`
<img width="366" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/66e8c25b-6cda-4490-99db-6532ef608195">


## Reference
#31 