### PR TITLE
WP-Builder: Feat/enum toggle control

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -9,6 +9,7 @@ import MultilineTextControl, { multilineTextControlTester } from "../renderers/P
 import ColorPaletteTextControl, { colorPaletteControlTester } from "../renderers/Primitive/ColorPaletteControl";
 import BooleanCheckboxControl, { booleanCheckboxControlTester } from "../renderers/Primitive/BooleanCheckboxControl";
 import BooleanToggleControl, { booleanToggleControlTester } from "../renderers/Primitive/BooleanToggleControl";
+import GutenbergToggleGroupControl, { gutenbergToggleGroupTester } from "../renderers/Primitive/ToggleGroupControl";
 import GutenbergObjectRenderer, { gutenbergObjectControlTester } from "../renderers/ObjectRenderer";
 import GutenbergArrayRenderer, { gutenbergArrayControlTester } from "../renderers/ArrayRenderer";
 import PortedArrayRenderer, { portedArrayControlTester } from "../renderers/PortedArrayRenderer";
@@ -36,6 +37,12 @@ const schema = {
           properties: {
             name: { type: 'string' },
           }
+        },
+        gender: {
+          type: "string",
+          enum: ["male", "female", "other"],
+          format: 'toggle-group',
+          description: "The gender of the user"
         },
         comments: {
           type: 'array',
@@ -99,6 +106,7 @@ const renderers = [
   { tester: colorPaletteControlTester, renderer: ColorPaletteTextControl },
   { tester: booleanToggleControlTester, renderer: BooleanToggleControl},
   { tester: booleanCheckboxControlTester, renderer: BooleanCheckboxControl},
+  { tester: gutenbergToggleGroupTester, renderer: GutenbergToggleGroupControl},
   { tester: gutenbergObjectControlTester, renderer: GutenbergObjectRenderer},
   { tester: gutenbergArrayControlTester, renderer: GutenbergArrayRenderer},
   // { tester: portedArrayControlTester, renderer: PortedArrayRenderer},

--- a/src/js/renderers/Primitive/ToggleGroupControl.js
+++ b/src/js/renderers/Primitive/ToggleGroupControl.js
@@ -38,8 +38,14 @@ export const GutenbergToggleGroup = props => {
   return !visible ? null : (
     <>
         <ToggleGroupControl label="my label" value="vertical" isBlock>
-            <ToggleGroupControlOption value="horizontal" label="Horizontal" />
-            <ToggleGroupControlOption value="vertical" label="Vertical" />
+            {options.map((option) => (
+                <ToggleGroupControlOption 
+                    value={option.value}
+                    key={option.label}
+                    label={option.label}
+                    disabled={!enabled}
+                />
+            ))}
         </ToggleGroupControl>
     </>
   )

--- a/src/js/renderers/Primitive/ToggleGroupControl.js
+++ b/src/js/renderers/Primitive/ToggleGroupControl.js
@@ -1,17 +1,21 @@
-import React from "react"
+import React from "react";
+import merge from "lodash/merge";
 import { 
     and, 
     isEnumControl, 
     formatIs, 
     rankWith 
-} from "@jsonforms/core"
-import { withJsonFormsEnumProps } from "@jsonforms/react"
+} from "@jsonforms/core";
+import { withJsonFormsEnumProps } from "@jsonforms/react";
 
-import merge from "lodash/merge"
-import { showAsRequired, isDescriptionHidden } from "@jsonforms/core"
+import { isDescriptionHidden } from "@jsonforms/core";
 import {
     __experimentalToggleGroupControl as ToggleGroupControl,
     __experimentalToggleGroupControlOption as ToggleGroupControlOption,
+    __experimentalVStack as VStack,
+	__experimentalSpacer as Spacer,
+	Tooltip,	
+    FlexItem,
 } from '@wordpress/components';
 
 export const GutenbergToggleGroup = props => {
@@ -38,25 +42,41 @@ export const GutenbergToggleGroup = props => {
     focused,
     appliedUiSchemaOptions.showUnfocusedDescription
   )
-  const onChange = (value) => handleChange(path, value)
+  const onChange = ( value ) => handleChange( path, value )
 
   return !visible ? null : (
     <>
-        <ToggleGroupControl 
-            label="my label" 
-            value="vertical" 
-            isBlock
-            onChange={onChange}
-        >
-            {options.map((option) => (
-                <ToggleGroupControlOption 
-                    value={option.value}
-                    key={option.label}
-                    label={option.label}
-                    disabled={!enabled}
-                />
-            ))}
-        </ToggleGroupControl>
+        <VStack justify="space-between">
+            <FlexItem>
+            { description ? (
+                <Tooltip text={ description }>
+                <label htmlFor={ id }>
+                    { label }
+                </label>
+            </Tooltip>
+            ) : ( 
+                <label htmlFor={ id }>
+                    { label }
+                </label> 
+            ) }
+            </FlexItem>
+            <FlexItem>
+                <ToggleGroupControl 
+                    value={ data }
+                    isBlock
+                    onChange={ onChange }
+                >
+                    {options.map((option) => (
+                        <ToggleGroupControlOption 
+                            value={option.value}
+                            key={option.label}
+                            label={option.label}
+                            disabled={!enabled}
+                        />
+                    ))}
+                </ToggleGroupControl>
+            </FlexItem>
+        </VStack>
     </>
   )
 }

--- a/src/js/renderers/Primitive/ToggleGroupControl.js
+++ b/src/js/renderers/Primitive/ToggleGroupControl.js
@@ -1,5 +1,10 @@
 import React from "react"
-import { and, isEnumControl, formatIs, rankWith } from "@jsonforms/core"
+import { 
+    and, 
+    isEnumControl, 
+    formatIs, 
+    rankWith 
+} from "@jsonforms/core"
 import { withJsonFormsEnumProps } from "@jsonforms/react"
 
 import merge from "lodash/merge"
@@ -33,11 +38,16 @@ export const GutenbergToggleGroup = props => {
     focused,
     appliedUiSchemaOptions.showUnfocusedDescription
   )
-  const onChange = (_ev, value) => handleChange(path, value)
+  const onChange = (value) => handleChange(path, value)
 
   return !visible ? null : (
     <>
-        <ToggleGroupControl label="my label" value="vertical" isBlock>
+        <ToggleGroupControl 
+            label="my label" 
+            value="vertical" 
+            isBlock
+            onChange={onChange}
+        >
             {options.map((option) => (
                 <ToggleGroupControlOption 
                     value={option.value}

--- a/src/js/renderers/Primitive/ToggleGroupControl.js
+++ b/src/js/renderers/Primitive/ToggleGroupControl.js
@@ -1,0 +1,56 @@
+import React from "react"
+import { and, isEnumControl, formatIs, rankWith } from "@jsonforms/core"
+import { withJsonFormsEnumProps } from "@jsonforms/react"
+
+import merge from "lodash/merge"
+import { showAsRequired, isDescriptionHidden } from "@jsonforms/core"
+import {
+    __experimentalToggleGroupControl as ToggleGroupControl,
+    __experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+
+export const GutenbergToggleGroup = props => {
+  const {
+    config,
+    id,
+    label,
+    required,
+    description,
+    errors,
+    data,
+    visible,
+    options,
+    handleChange,
+    path,
+    enabled
+  } = props
+  const focused = true;
+  const isValid = errors.length === 0
+  const appliedUiSchemaOptions = merge({}, config, props.uischema.options)
+  const showDescription = !isDescriptionHidden(
+    visible,
+    description,
+    focused,
+    appliedUiSchemaOptions.showUnfocusedDescription
+  )
+  const onChange = (_ev, value) => handleChange(path, value)
+
+  return !visible ? null : (
+    <>
+        <ToggleGroupControl label="my label" value="vertical" isBlock>
+            <ToggleGroupControlOption value="horizontal" label="Horizontal" />
+            <ToggleGroupControlOption value="vertical" label="Vertical" />
+        </ToggleGroupControl>
+    </>
+  )
+}
+
+export const GutenbergToggleGroupControl = props => {
+  return <GutenbergToggleGroup {...props} />
+}
+
+export const gutenbergToggleGroupTester = rankWith(
+  21,
+  and(isEnumControl, formatIs("toggle-group"))
+)
+export default withJsonFormsEnumProps(GutenbergToggleGroupControl)


### PR DESCRIPTION
## Summary
- Implement the Enum control with Toggle

Screenshot
<img width="383" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/5d670834-987d-49fa-ab75-f90c23dafad4">

## Reference
https://github.com/bangank36/WP-Builder/issues/40