### PR TITLE
WP-Builder: Fix root node missing ui controls

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -78,20 +78,11 @@ const schema = {
 };
 
 const uischema = {
-  type: "NavigatorLayout",
+  type: 'NavigatorLayout',
   elements: [
     {
-      type: 'VerticalLayout',
-      elements: [
-        {
-          type: 'Control',
-          scope: '#/properties/address',
-        },
-        {
-          type: 'Control',
-          scope: '#/properties/business',
-        }
-      ],
+      type: 'Control',
+      scope: '#',
     }
   ],
 }

--- a/src/js/renderers/NavigatorLayout.js
+++ b/src/js/renderers/NavigatorLayout.js
@@ -85,7 +85,6 @@ const MemoizedChildComponent = (({ component, label, path } ) => {
 
 MemoizedChildComponent.whyDidYouRender = true
 
-
 export const GutenbergNavigatorlLayoutRenderer = ({
     uischema,
     schema,

--- a/src/js/renderers/NavigatorLayout.js
+++ b/src/js/renderers/NavigatorLayout.js
@@ -124,16 +124,16 @@ export const GutenbergNavigatorlLayoutRenderer = ({
                         >
                             <CardBody>
                                 <MaterialLayoutRenderer
-                                    {...childProps}
-                                    renderers={renderers}
-                                    cells={cells}
+                                    { ...childProps }
+                                    renderers={ renderers }
+                                    cells={ cells }
                                 />
                             </CardBody>
                         </Card>
                     </NavigatorScreen>
                 ) }
 
-                {Object.keys( screenContent ).map(( route, index ) => (
+                {Object.keys( screenContent ).map((  route, index ) => (
                     <NavigatorScreen path={ `${route}` }>
                         <Card
                             size="small"
@@ -175,15 +175,11 @@ export const GutenbergNavigatorlLayoutRenderer = ({
                                     </NavigationButtonAsItem>
                                 </HStack>
                             ) : null }
-                            <MemoizedChildComponent {...screenContent[route]}>
-                            
-                            </MemoizedChildComponent>
-                            
-                           
+                            <MemoizedChildComponent {...screenContent[route]} />
                         </CardBody>
                         </Card>
                     </NavigatorScreen>
-                ))}
+                ) ) }
             </NavigatorProvider>
         </NavigatorContext.Provider>
       </>

--- a/src/js/renderers/NavigatorLayout.js
+++ b/src/js/renderers/NavigatorLayout.js
@@ -115,21 +115,23 @@ export const GutenbergNavigatorlLayoutRenderer = ({
       <>
         <NavigatorContext.Provider value={[screenContent, setScreenContent]}>
           <NavigatorProvider initialPath="/">
-              <NavigatorScreen path="/">
-                    <Card
-                        size="small"
-                        isBorderless
-                        className="jsonforms-navigator-layout-screen"
-                    >
-                        <CardBody>
-                            <MaterialLayoutRenderer
-                                {...childProps}
-                                renderers={renderers}
-                                cells={cells}
-                            />
-                        </CardBody>
-                    </Card>
-                </NavigatorScreen>
+                { screenContent.hasOwnProperty("/") ? null : (
+                    <NavigatorScreen path="/">
+                        <Card
+                            size="small"
+                            isBorderless
+                            className="jsonforms-navigator-layout-screen"
+                        >
+                            <CardBody>
+                                <MaterialLayoutRenderer
+                                    {...childProps}
+                                    renderers={renderers}
+                                    cells={cells}
+                                />
+                            </CardBody>
+                        </Card>
+                    </NavigatorScreen>
+                ) }
 
                 {Object.keys( screenContent ).map(( route, index ) => (
                     <NavigatorScreen path={ `${route}` }>
@@ -139,38 +141,40 @@ export const GutenbergNavigatorlLayoutRenderer = ({
                             className="jsonforms-navigator-layout-screen"
                         >
                         <CardBody>
-                            <HStack spacing={ 2 }>
-                                <NavigatorToParentButton
-                                    style={
-                                        // TODO: This style override is also used in ToolsPanelHeader.
-                                        // It should be supported out-of-the-box by Button.
-                                        { minWidth: 24, padding: 0 }
-                                    }
-                                    icon={ isRTL() ? chevronRight : chevronLeft }
-                                    isSmall
-                                    aria-label={ __( 'Navigate to the previous view' ) }
-                                />
-                                <Spacer>
-                                    <Heading
-                                    className="jsonforms-navigator-screen-header"
-                                    level={ 2 }
-                                    size={ 13 }
-                                    >
-                                    { screenContent[route].label }
-                                    </Heading>
-                                </Spacer>
-            
-                                <NavigationButtonAsItem
-                                    path={'/'}
-                                    aria-label={ __( 'Navigate to the main view' ) }
-                                >
-                                    <HStack justify="flex-end">
-                                    <IconWithCurrentColor
-                                        icon={ home }
+                            { route !== '/' ? (
+                                <HStack spacing={ 2 }>
+                                    <NavigatorToParentButton
+                                        style={
+                                            // TODO: This style override is also used in ToolsPanelHeader.
+                                            // It should be supported out-of-the-box by Button.
+                                            { minWidth: 24, padding: 0 }
+                                        }
+                                        icon={ isRTL() ? chevronRight : chevronLeft }
+                                        isSmall
+                                        aria-label={ __( 'Navigate to the previous view' ) }
                                     />
-                                    </HStack>
-                                </NavigationButtonAsItem>
-                            </HStack>
+                                    <Spacer>
+                                        <Heading
+                                        className="jsonforms-navigator-screen-header"
+                                        level={ 2 }
+                                        size={ 13 }
+                                        >
+                                        { screenContent[route].label }
+                                        </Heading>
+                                    </Spacer>
+                
+                                    <NavigationButtonAsItem
+                                        path={'/'}
+                                        aria-label={ __( 'Navigate to the main view' ) }
+                                    >
+                                        <HStack justify="flex-end">
+                                        <IconWithCurrentColor
+                                            icon={ home }
+                                        />
+                                        </HStack>
+                                    </NavigationButtonAsItem>
+                                </HStack>
+                            ) : null }
                             <MemoizedChildComponent {...screenContent[route]}>
                             
                             </MemoizedChildComponent>


### PR DESCRIPTION
## Summary
- This PR found the root cause of the issue where the NavigatorLayout can not render the controls on the root scope ( so far it only render the nested props like /address or /business )
  - If the root scope `#` is defined, jsonforms will render the root layout as `VerticalLayout` with root path ( "" ), this leads to the Navigator Screen context is given a `/` screen, we need to check wether the context contains the root path to replace the default main screen with it

- Recording
![chrome-capture-2023-6-17 (1)](https://github.com/bangank36/WP-Builder/assets/10071857/cb80133d-3f3d-4dc5-9dc0-2e321e4197d2)



## Reference
https://github.com/bangank36/WP-Builder/issues/44