### PR TITLE
WP-Builder: Pass contentType to context

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -12,7 +12,7 @@ import BooleanToggleControl, { booleanToggleControlTester } from "../renderers/P
 import GutenbergToggleGroupControl, { gutenbergToggleGroupTester } from "../renderers/Primitive/ToggleGroupControl";
 import GutenbergToggleGroupOneOfControl, { gutenbergToggleGroupOneOfTester } from "../renderers/Primitive/ToggleGroupOneOfControl";
 import GutenbergObjectRenderer, { gutenbergObjectControlTester } from "../renderers/ObjectRenderer";
-import GutenbergArrayRenderer, { gutenbergArrayControlTester } from "../renderers/ArrayRenderer";
+import GutenbergArrayRenderer, { gutenbergArrayControlTester } from "../renderers/ArrayControlRenderer";
 import PortedArrayRenderer, { portedArrayControlTester } from "../renderers/PortedArrayRenderer";
 import GutenbergNavigatorlLayoutRenderer, { gutenbergNavigatorLayoutTester } from "../renderers/NavigatorLayout";
 

--- a/src/js/renderers/ArrayControlRenderer.js
+++ b/src/js/renderers/ArrayControlRenderer.js
@@ -1,0 +1,186 @@
+import isEmpty from 'lodash/isEmpty';
+import range from 'lodash/range';
+import {
+    composePaths,
+    findUISchema,
+    Generate,
+    isPrimitiveArrayControl,
+    isObjectArrayControl,
+    rankWith,
+    or
+} from '@jsonforms/core';
+import { 
+    JsonFormsDispatch, 
+    withJsonFormsArrayControlProps,
+    withJsonFormsDetailProps,
+ } from '@jsonforms/react';
+import React, { useMemo, useContext, useEffect } from 'react';
+import { Context as NavigatorContext } from '../component/context'
+
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { isRTL, __ } from '@wordpress/i18n';
+import { IconWithCurrentColor } from './NavigatorLayout/icon-with-current-color';
+import { NavigationButtonAsItem } from './NavigatorLayout/navigation-button';
+
+import {
+    __experimentalUseNavigator as useNavigator,
+	__experimentalHStack as HStack,
+    __experimentalItemGroup as ItemGroup,
+	__experimentalItem as Item,
+	FlexItem,
+} from '@wordpress/components';
+
+export const GutenbergArrayRenderer = (props) => {
+    const {
+        data,
+        renderers,
+        cells,
+        uischemas,
+        schema,
+        label,
+        path,
+        visible,
+        enabled,
+        uischema,
+        rootSchema,
+    } = props;
+
+    const detailUiSchema = useMemo(
+        () =>
+        findUISchema(
+            uischemas,
+            schema,
+            uischema.scope,
+            path,
+            () =>
+            isEmpty(path)
+                ? Generate.uiSchema(schema, 'VerticalLayout')
+                : { ...Generate.uiSchema(schema, 'Group'), label },
+            uischema,
+            rootSchema
+        ),
+        [uischemas, schema, uischema.scope, path, label, uischema, rootSchema]
+    );
+
+    const childUiSchema = useMemo(
+        () =>
+        findUISchema(
+            uischemas,
+            schema,
+            uischema.scope,
+            path,
+            () =>
+            isEmpty(path)
+                ? Generate.uiSchema(schema, 'VerticalLayout')
+                : { ...Generate.uiSchema(schema, 'Group'), label },
+            uischema,
+            rootSchema
+        ),
+        [uischemas, schema, uischema.scope, path, label, uischema, rootSchema]
+    );
+
+    // Util to convert dot path into slash path: eg: address.country -> /address/country
+    const route = '/' + path.split('.').join('/');
+
+    const [screenContent, setScreenContent] = useContext(NavigatorContext);
+
+    const navigator = useNavigator();
+    console.log(navigator);
+
+    //UseEffect to fix the issue Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate.
+    useEffect(() => {
+        // Use the callback since the new state is based on the previous state
+        setScreenContent(prevScreenContent => ({
+            ...prevScreenContent,
+            [`${route}`]: {
+                component: ({
+                    renderers,
+                    cells,
+                    uischemas,
+                    schema,
+                    label,
+                    path,
+                    visible,
+                    enabled,
+                    uischema: detailUiSchema,
+                    rootSchema,
+                    data
+                }),
+                label: detailUiSchema.label,
+                path: path,
+                contentType: 'array'
+            },
+            [`${route}/:index`]: {
+                component: (
+                {    
+                    renderers,
+                    cells,
+                    uischemas,
+                    schema,
+                    label,
+                    path: composePaths(path, `${0}`),
+                    visible,
+                    enabled,
+                    uischema: childUiSchema,
+                    rootSchema,
+                }),
+                label: detailUiSchema.label,
+                path: path
+            },
+        }))
+    }, [route])
+
+    return !visible ? null : (
+        <>
+            <NavigationButtonAsItem
+                path={`${route}`}
+                aria-label={detailUiSchema.label}
+            >
+                <HStack justify="space-between">
+                <FlexItem>
+                    Edit {detailUiSchema.label}
+                </FlexItem>
+                <IconWithCurrentColor
+                    icon={isRTL() ? chevronLeft : chevronRight}
+                />
+                </HStack>
+            </NavigationButtonAsItem>
+            <ItemGroup 
+                isBordered={true} 
+                isSeparated={true}
+                size="small"
+            >
+                {(data )? (
+                    range(0, data.length).map((index) => {
+                        const childPath = composePaths(path, `${index}`);
+                        return (
+                            <Item key={index}>
+                                <NavigationButtonAsItem
+                                    path={`${route}/${index}`}
+                                    aria-label={detailUiSchema.label}
+                                >
+                                    <HStack justify="space-between">
+                                    <FlexItem>
+                                        item #{index}
+                                    </FlexItem>
+                                    <IconWithCurrentColor
+                                        icon={isRTL() ? chevronLeft : chevronRight}
+                                    />
+                                    </HStack>
+                                </NavigationButtonAsItem>
+                            </Item>
+                        )
+                    }) 
+                ) : null}
+            </ItemGroup>
+            
+        </>
+  )
+};
+
+export const gutenbergArrayControlTester = rankWith(
+    9,
+    or(isObjectArrayControl, isPrimitiveArrayControl)
+);
+
+export default withJsonFormsArrayControlProps(GutenbergArrayRenderer);

--- a/src/js/renderers/NavigatorLayout.js
+++ b/src/js/renderers/NavigatorLayout.js
@@ -36,12 +36,11 @@ export const gutenbergNavigatorLayoutTester = rankWith(
     uiTypeIs("NavigatorLayout")
 )
 
-const MemoizedChildComponent = ( ( { component, label, path } ) => {
+const MemoizedChildComponent = ( ( { component, label, path, contentType } ) => {
     const navigator = useNavigator();
-    console.log('screen rerendered');
 
     // Below 2 conditions are hard coded to handle the array renderers
-    if ( navigator.location.path === '/address/comments' ) {
+    if ( contentType === 'array' ) {
         return (
             component.data ? (
                 range( 0, component.data.length ).map(( index ) => {


### PR DESCRIPTION
## Summary
- So I pass the `contentType` props to context in order to identify the current control is Array

## Reference
https://github.com/bangank36/WP-Builder/issues/47