### PR TITLE
WP-Builder: Manual connect jsonform context to ArrayControl props

### DIFF
--- a/src/js/renderers/ArrayControlRenderer.js
+++ b/src/js/renderers/ArrayControlRenderer.js
@@ -1,5 +1,4 @@
 import isEmpty from 'lodash/isEmpty';
-import range from 'lodash/range';
 import {
     composePaths,
     findUISchema,
@@ -10,9 +9,9 @@ import {
     or
 } from '@jsonforms/core';
 import { 
-    JsonFormsDispatch, 
-    withJsonFormsArrayControlProps,
-    withJsonFormsDetailProps,
+    useJsonForms,
+    ctxToArrayControlProps,
+    ctxDispatchToArrayControlProps
  } from '@jsonforms/react';
 import React, { useMemo, useContext, useEffect } from 'react';
 import { Context as NavigatorContext } from '../component/context'
@@ -25,14 +24,21 @@ import { NavigationButtonAsItem } from './NavigatorLayout/navigation-button';
 import {
     __experimentalUseNavigator as useNavigator,
 	__experimentalHStack as HStack,
-    __experimentalItemGroup as ItemGroup,
-	__experimentalItem as Item,
 	FlexItem,
 } from '@wordpress/components';
 
-export const GutenbergArrayRenderer = (props) => {
+export const GutenbergArrayRenderer = (ownControlProps) => {
+    const ctx = useJsonForms();
+    const stateProps = ctxToArrayControlProps(ctx, ownControlProps);
+    const dispatchProps = ctxDispatchToArrayControlProps(ctx.dispatch);
+
+    const props = {
+        ...ownControlProps,
+        ...stateProps,
+        ...dispatchProps
+    }
+
     const {
-        data,
         renderers,
         cells,
         uischemas,
@@ -94,7 +100,7 @@ export const GutenbergArrayRenderer = (props) => {
             ...prevScreenContent,
             [`${route}`]: {
                 component: ( {
-                    ...props
+                    ...ownControlProps
                 } ),
                 label: detailUiSchema.label,
                 path: path,
@@ -161,4 +167,4 @@ export const gutenbergArrayControlTester = rankWith(
     or(isObjectArrayControl, isPrimitiveArrayControl)
 );
 
-export default withJsonFormsArrayControlProps(GutenbergArrayRenderer);
+export default GutenbergArrayRenderer;

--- a/src/js/renderers/NavigatorLayout.js
+++ b/src/js/renderers/NavigatorLayout.js
@@ -7,7 +7,8 @@ import {
 } from "@jsonforms/core";
 import { 
     withJsonFormsLayoutProps,
-    JsonFormsDispatch 
+    JsonFormsDispatch,
+    withJsonFormsArrayControlProps 
 } from "@jsonforms/react"
 import { Context as NavigatorContext } from '../component/context'
 import { chevronLeft, chevronRight } from '@wordpress/icons';
@@ -23,7 +24,7 @@ import {
 } from '@wordpress/components';
 
 import { NavigatorLayoutRenderer } from "./NavigatorRenderer";
-import { ArrayControlRenderer } from "./ArrayLayoutRenderer";
+import ArrayControlRenderer from "./ArrayLayoutRenderer";
 import { IconWithCurrentColor } from './NavigatorLayout/icon-with-current-color';
 import { NavigationButtonAsItem } from './NavigatorLayout/navigation-button';
 import NavigatorTopToolbar from './NavigatorLayout/navigator-top-toolbar';


### PR DESCRIPTION
## Summary
Implement the fix for array renderer not react to data change by manually connect Array Control props to `jsonforms context`

## Reference
#54