### PR TITLE
WP-Builder: Rename navigator context screen prop

### DIFF
--- a/src/js/renderers/ArrayControlRenderer.js
+++ b/src/js/renderers/ArrayControlRenderer.js
@@ -98,16 +98,16 @@ export const GutenbergArrayRenderer = (ownControlProps) => {
         // Use the callback since the new state is based on the previous state
         setScreenContent(prevScreenContent => ({
             ...prevScreenContent,
-            [`${route}`]: {
-                component: ( {
+            [ `${route}` ]: {
+                rendererProps: ( {
                     ...ownControlProps
                 } ),
                 label: detailUiSchema.label,
                 path: path,
                 contentType: 'array'
             },
-            [`${route}/:index`]: {
-                component: (
+            [ `${route}/:index` ]: {
+                rendererProps: (
                 {    
                     renderers,
                     cells,
@@ -123,9 +123,8 @@ export const GutenbergArrayRenderer = (ownControlProps) => {
                 label: detailUiSchema.label,
                 path: path
             },
-			[`${route}/new`]: {
-                component: (
-                {    
+			[ `${route}/new` ]: {
+                rendererProps: ( {    
                     renderers,
                     cells,
                     uischemas,
@@ -136,12 +135,12 @@ export const GutenbergArrayRenderer = (ownControlProps) => {
                     enabled,
                     uischema: childUiSchema,
                     rootSchema,
-                }),
+                } ),
                 label: detailUiSchema.label,
                 path: path
             },
         }))
-    }, [route])
+    }, [ route ] )
 
     return !visible ? null : (
         <>

--- a/src/js/renderers/NavigatorLayout.js
+++ b/src/js/renderers/NavigatorLayout.js
@@ -38,27 +38,27 @@ export const gutenbergNavigatorLayoutTester = rankWith(
     uiTypeIs("NavigatorLayout")
 )
 
-const MemoizedChildComponent = ( ( { component, label, path, contentType } ) => {
+const MemoizedChildComponent = ( ( { rendererProps, label, path, contentType } ) => {
     const navigator = useNavigator();
 
     // Handle array renderer
     if ( contentType === 'array' ) {
         return (
-            <ArrayControlRenderer { ...component }/>
+            <ArrayControlRenderer { ...rendererProps }/>
         )
     }
 
     if ( navigator.params.index ) {
         const childPath = composePaths( path, `${ navigator.params.index }` );
-        const childComp = {
-            ...component,
+        const childRendererProps = {
+            ...rendererProps,
             path: childPath
         }
 
-        return <JsonFormsDispatch { ...childComp }/>
+        return <JsonFormsDispatch { ...childRendererProps }/>
     }
 
-    return <JsonFormsDispatch { ...component }/>
+    return <JsonFormsDispatch { ...rendererProps }/>
 })
 
 MemoizedChildComponent.whyDidYouRender = true

--- a/src/js/renderers/ObjectRenderer.js
+++ b/src/js/renderers/ObjectRenderer.js
@@ -57,15 +57,15 @@ export const GutenbergObjectRenderer = ({
   const [screenContent, setScreenContent] = useContext(NavigatorContext);
 
   //UseEffect to fix the issue Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate.
-  useEffect(() => {
-    if (!route) {
+  useEffect( () => {
+    if ( !route ) {
       return;
     }
     // Use the callback since the new state is based on the previous state
-    setScreenContent(prevScreenContent => ({
+    setScreenContent(prevScreenContent => ( {
       ...prevScreenContent,
-      [route]: {
-        component: ({
+      [ route ]: {
+        rendererProps: ( {
           renderers,
           cells,
           uischemas,
@@ -76,12 +76,12 @@ export const GutenbergObjectRenderer = ({
           enabled,
           uischema: detailUiSchema,
           rootSchema,
-        }),
+        } ),
         label: detailUiSchema.label,
         path: path
       }
-    }))
-  }, [route])
+    } ) )
+  }, [route] )
 
   return !visible ? null : (
     <>


### PR DESCRIPTION
## Summary
Rename prop name from `component` to `rendererProps`

## Reference
https://github.com/bangank36/WP-Builder/issues/53