### PR TITLE
WP-Builder: Feat/implement add new

### DIFF
--- a/src/js/renderers/ArrayLayoutRenderer.js
+++ b/src/js/renderers/ArrayLayoutRenderer.js
@@ -1,42 +1,15 @@
-/*
-  The MIT License
-  Copyright (c) 2017-2019 EclipseSource Munich
-  https://github.com/eclipsesource/jsonforms
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-  The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-  THE SOFTWARE.
-*/
 import range from "lodash/range"
-import React, { useMemo, useContext, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import {
-  composePaths,
-  createDefaultValue,
-  findUISchema,
-  Helpers,
-  rankWith,
-  or,
-  isPrimitiveArrayControl,
-  isObjectArrayControl,
-  isObjectArrayWithNesting
+	composePaths,
+	createDefaultValue,
+	findUISchema,
+	Helpers
 } from "@jsonforms/core"
 import {
   JsonFormsDispatch,
   withJsonFormsArrayControlProps
 } from "@jsonforms/react"
-
-import { Context as NavigatorContext } from '../component/context';
 
 import { chevronLeft, chevronRight, plus } from '@wordpress/icons';
 import { isRTL, __ } from '@wordpress/i18n';
@@ -49,181 +22,186 @@ import {
     __experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
 	FlexItem,
+	Button
 } from '@wordpress/components';
 
 const { convertToValidClassName } = Helpers
 
-export const ArrayControl = ({
-  classNames,
-  data,
-  label,
-  path,
-  schema,
-  errors,
-  addItem,
-  removeItems,
-  moveUp,
-  moveDown,
-  uischema,
-  uischemas,
-  getStyleAsClassName = (cls) => cls,
-  renderers,
-  rootSchema,
-  translations
-}) => {
-
+// TODO: add new item button component
+const AddItemButton = ({ route, path, label, schema, addItem }) => {
 	const navigator = useNavigator();
-  const controlElement = uischema
-  const childUiSchema = useMemo(
-    () =>
-      findUISchema(
-        uischemas,
-        schema,
-        uischema.scope,
-        path,
-        undefined,
-        uischema,
-        rootSchema
-      ),
-    [uischemas, schema, uischema.scope, path, uischema, rootSchema]
-  )
-  const isValid = errors.length === 0
-  const validationClass = getStyleAsClassName("array.control.validation")
-  const divClassNames = [validationClass]
-    .concat(
-      isValid ? "" : getStyleAsClassName("array.control.validation.error")
-    )
-    .join(" ")
-  const buttonClassAdd = getStyleAsClassName("array.control.add")
-  const labelClass = getStyleAsClassName("array.control.label")
-  const childControlsClass = getStyleAsClassName("array.child.controls")
-  const buttonClassUp = getStyleAsClassName("array.child.controls.up")
-  const buttonClassDown = getStyleAsClassName("array.child.controls.down")
-  const buttonClassDelete = getStyleAsClassName("array.child.controls.delete")
-  const controlClass = [
-    getStyleAsClassName("array.control"),
-    convertToValidClassName(controlElement.scope)
-  ].join(" ")
-
-  // Util to convert dot path into slash path: eg: address.country -> /address/country
-  const route = '/' + path.split('.').join('/');
-
-  return (
-    <div className={controlClass}>
-      	<header>
-			<label className={labelClass}>{label}</label>
-			<button
-			className={buttonClassAdd}
-			onClick={() => {
-				addItem(path, createDefaultValue(schema))();
-				navigator.goTo('/address/comments/2');
-			}}
+	return (
+		<Button
+			aria-label={ `Add new item` }
+			onClick={ () => {
+				addItem( path, createDefaultValue(schema) )();
+				navigator.goTo( route );
+			} }
+		>
+			<HStack 
+				justify="center"
 			>
-			Add to {label}
-			</button>
-      	</header>
-      	<div className={divClassNames}>{errors}</div>
-		<div className={classNames.children}>
-			{data ? (
-			range(0, data.length).map(index => {
-				const childPath = composePaths(path, `${index}`)
-				return (
-				<div key={index}>
-					<JsonFormsDispatch
-					schema={schema}
-					uischema={childUiSchema || uischema}
-					path={childPath}
-					key={childPath}
-					renderers={renderers}
-					/>
-					<div className={childControlsClass}>
-					<button
-						className={buttonClassUp}
-						aria-label={translations.upAriaLabel}
-						onClick={() => {
-						moveUp(path, index)()
-						}}
-					>
-						{translations.up}
-					</button>
-					<button
-						className={buttonClassDown}
-						aria-label={translations.downAriaLabel}
-						onClick={() => {
-						moveDown(path, index)()
-						}}
-					>
-						{translations.down}
-					</button>
-					<button
-						className={buttonClassDelete}
-						aria-label={translations.removeAriaLabel}
-						onClick={() => {
-						if (
-							window.confirm(
-							"Are you sure you wish to delete this item?"
-							)
-						) {
-							removeItems(path, [index])()
-						}
-						}}
-					>
-						{translations.removeTooltip}
-					</button>
+			<FlexItem>
+				<IconWithCurrentColor
+					icon={ plus }
+				/>Add { label }
+			</FlexItem>
+			</HStack>
+		</Button>
+	);
+}
+
+export const ArrayControl = ( {
+	classNames,
+	data,
+	label,
+	path,
+	schema,
+	errors,
+	addItem,
+	removeItems,
+	moveUp,
+	moveDown,
+	uischema,
+	uischemas,
+	getStyleAsClassName = (cls) => cls,
+	renderers,
+	rootSchema,
+	translations
+} ) => {
+
+  	const controlElement = uischema
+  	const childUiSchema = useMemo(
+		() =>
+		findUISchema(
+			uischemas,
+			schema,
+			uischema.scope,
+			path,
+			undefined,
+			uischema,
+			rootSchema
+		),
+		[ uischemas, schema, uischema.scope, path, uischema, rootSchema ]
+	)
+  	const isValid = errors.length === 0
+  	const validationClass = getStyleAsClassName("array.control.validation")
+  	const divClassNames = [validationClass]
+    	.concat(
+      		isValid ? "" : getStyleAsClassName("array.control.validation.error")
+    	)
+    	.join(" ")
+	const buttonClassAdd = getStyleAsClassName("array.control.add")
+	const labelClass = getStyleAsClassName("array.control.label")
+	const childControlsClass = getStyleAsClassName("array.child.controls")
+	const buttonClassUp = getStyleAsClassName("array.child.controls.up")
+	const buttonClassDown = getStyleAsClassName("array.child.controls.down")
+	const buttonClassDelete = getStyleAsClassName("array.child.controls.delete")
+	const controlClass = [
+		getStyleAsClassName("array.control"),
+		convertToValidClassName(controlElement.scope)
+	].join(" ")
+
+	// Util to convert dot path into slash path: eg: address.country -> /address/country
+	const route = '/' + path.split('.').join('/');
+
+  	return (
+    	<div className={controlClass}>
+      		<div className={divClassNames}>{errors}</div>
+			<div className={classNames.children}>
+				{data ? (
+				range(0, data.length).map(index => {
+					const childPath = composePaths(path, `${index}`)
+					return (
+					<div key={index}>
+						<JsonFormsDispatch
+						schema={schema}
+						uischema={childUiSchema || uischema}
+						path={childPath}
+						key={childPath}
+						renderers={renderers}
+						/>
+						<div className={childControlsClass}>
+						<button
+							className={buttonClassUp}
+							aria-label={translations.upAriaLabel}
+							onClick={() => {
+							moveUp(path, index)()
+							}}
+						>
+							{translations.up}
+						</button>
+						<button
+							className={buttonClassDown}
+							aria-label={translations.downAriaLabel}
+							onClick={() => {
+							moveDown(path, index)()
+							}}
+						>
+							{translations.down}
+						</button>
+						<button
+							className={buttonClassDelete}
+							aria-label={translations.removeAriaLabel}
+							onClick={() => {
+							if (
+								window.confirm(
+								"Are you sure you wish to delete this item?"
+								)
+							) {
+								removeItems(path, [index])()
+							}
+							}}
+						>
+							{translations.removeTooltip}
+						</button>
+						</div>
 					</div>
-				</div>
-				)
-			})
-			) : (
-			<p>{translations.noDataMessage}</p>
-			)}
-		</div>
-	  <ItemGroup 
+					)
+				})
+				) : (
+				<p>{translations.noDataMessage}</p>
+				)}
+			</div>
+	  		<ItemGroup 
                 isBordered={true} 
                 isSeparated={true}
                 size="small"
             >
-                {(data )? (
-                    range(0, data.length).map((index) => {
-                        const childPath = composePaths(path, `${index}`);
+                { ( data )? (
+                    range( 0, data.length ).map(( index ) => {
+                        const childPath = composePaths( path, `${index}` );
                         return (
-                            <Item key={index}>
+                            <Item key={ index }>
                                 <NavigationButtonAsItem
                                     path={ `${route}/${index}` }
                                     aria-label={ `Item #${index}` }
                                 >
                                     <HStack justify="space-between">
                                     <FlexItem>
-                                        item #{index}
+                                        item #{ index }
                                     </FlexItem>
                                     <IconWithCurrentColor
-                                        icon={isRTL() ? chevronLeft : chevronRight}
+                                        icon={ isRTL() ? chevronLeft : chevronRight }
                                     />
                                     </HStack>
                                 </NavigationButtonAsItem>
                             </Item>
                         )
-                    }) 
-                ) : null}
+                    } ) 
+                ) : null }
 				<Item>
-					<NavigationButtonAsItem
-						path={ `${route}/new` }
-						aria-label={ `Add new item` }
-					>
-						<HStack 
-							justify="center"
-						>
-						<FlexItem>
-							<IconWithCurrentColor
-								icon={ plus }
-							/>Add { label }
-						</FlexItem>
-						</HStack>
-					</NavigationButtonAsItem>
+					<AddItemButton 
+						schema={ schema }
+						label={ label } 
+						path={ path }
+						route={ `${ route }/${ data.length }` } 
+						addItem={ addItem }
+					/>
 				</Item>
             </ItemGroup>
-    </div>
-  )
+    	</div>
+  	)
 }
 
 export const ArrayControlRenderer = ( props ) => {

--- a/src/js/renderers/ArrayLayoutRenderer.js
+++ b/src/js/renderers/ArrayLayoutRenderer.js
@@ -44,6 +44,7 @@ import { IconWithCurrentColor } from './NavigatorLayout/icon-with-current-color'
 import { NavigationButtonAsItem } from './NavigatorLayout/navigation-button';
 
 import {
+	__experimentalUseNavigator as useNavigator,
 	__experimentalHStack as HStack,
     __experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
@@ -70,6 +71,8 @@ export const ArrayControl = ({
   rootSchema,
   translations
 }) => {
+
+	const navigator = useNavigator();
   const controlElement = uischema
   const childUiSchema = useMemo(
     () =>
@@ -111,7 +114,10 @@ export const ArrayControl = ({
 			<label className={labelClass}>{label}</label>
 			<button
 			className={buttonClassAdd}
-			onClick={addItem(path, createDefaultValue(schema))}
+			onClick={() => {
+				addItem(path, createDefaultValue(schema))();
+				navigator.goTo('/address/comments/2');
+			}}
 			>
 			Add to {label}
 			</button>

--- a/src/js/renderers/NavigatorLayout.js
+++ b/src/js/renderers/NavigatorLayout.js
@@ -110,7 +110,7 @@ export const GutenbergNavigatorlLayoutRenderer = ( {
                 ) }
 
                 { Object.keys( screenContent ).map((  route, index ) => (
-                    <NavigatorScreen path={ `${route}` }>
+                    <NavigatorScreen path={ `${route}` } key={ index }>
                         <Card
                             size="small"
                             isBorderless


### PR DESCRIPTION
## Summary
- Implement the `add new` button on array Navigator screen
- When click it will add new item to the array with default value and navigates to the new item screen for edit
- Currently the item name is `Item {index}`, which make it hard to identify the actual item and make the sorting button won't work as expected, since the index will still be same when iterate over data array regardless the order of the item. We should display the item using `label` `description` or somekind of name

## Testing
- Checkout this branch
- Run `npm run start`
- Confirm the add new item button works as expected
![chrome-capture-2023-6-19 (1)](https://github.com/bangank36/WP-Builder/assets/10071857/b57bb749-f118-469b-8664-ec4da70e2aeb)

## Reference
https://github.com/bangank36/WP-Builder/issues/51