### PR TITLE
WP-Builder: Feat/array item actions

### DIFF
--- a/src/js/renderers/ArrayLayoutRenderer.js
+++ b/src/js/renderers/ArrayLayoutRenderer.js
@@ -37,9 +37,7 @@ const ItemActionsMenu = ( { onEdit, onDuplicate, onRemove } ) => (
     <DropdownMenu icon={ moreVertical } label="Select an action">
         { () => (
             <>
-                <MenuGroup
-					style={ { width: 200 } }
-				>
+                <MenuGroup>
                     <MenuItem icon={ edit } onClick={ onEdit }>
                         Edit
                     </MenuItem>

--- a/src/js/renderers/ArrayLayoutRenderer.js
+++ b/src/js/renderers/ArrayLayoutRenderer.js
@@ -1,7 +1,6 @@
 import range from "lodash/range"
 import React, { useMemo } from 'react';
 import {
-	composePaths,
 	createDefaultValue,
 	findUISchema,
 	Helpers
@@ -12,15 +11,13 @@ import {
 } from "@jsonforms/react"
 
 import { 
-	chevronLeft, 
-	chevronRight, 
 	plus,
 	moreVertical, 
 	edit, 
 	copy, 
 	trash 
 } from '@wordpress/icons';
-import { isRTL, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { IconWithCurrentColor } from './NavigatorLayout/icon-with-current-color';
 import { NavigationButtonAsItem } from './NavigatorLayout/navigation-button';
 
@@ -62,7 +59,6 @@ const ItemActionsMenu = ( { onEdit, onDuplicate, onRemove } ) => (
 
 const { convertToValidClassName } = Helpers
 
-// TODO: add new item button component
 const AddItemButton = ({ route, path, label, schema, addItem }) => {
 	const navigator = useNavigator();
 	
@@ -97,109 +93,16 @@ export const ArrayControl = ( {
 	addItem,
 	removeItems,
 	moveUp,
-	moveDown,
-	uischema,
-	uischemas,
-	getStyleAsClassName = (cls) => cls,
-	renderers,
-	rootSchema,
-	translations
+	moveDown
 } ) => {
 	const navigator = useNavigator();
-
-  	const controlElement = uischema
-  	const childUiSchema = useMemo(
-		() =>
-		findUISchema(
-			uischemas,
-			schema,
-			uischema.scope,
-			path,
-			undefined,
-			uischema,
-			rootSchema
-		),
-		[ uischemas, schema, uischema.scope, path, uischema, rootSchema ]
-	)
-  	const isValid = errors.length === 0
-  	const validationClass = getStyleAsClassName("array.control.validation")
-  	const divClassNames = [validationClass]
-    	.concat(
-      		isValid ? "" : getStyleAsClassName("array.control.validation.error")
-    	)
-    	.join(" ")
-	const buttonClassAdd = getStyleAsClassName("array.control.add")
-	const labelClass = getStyleAsClassName("array.control.label")
-	const childControlsClass = getStyleAsClassName("array.child.controls")
-	const buttonClassUp = getStyleAsClassName("array.child.controls.up")
-	const buttonClassDown = getStyleAsClassName("array.child.controls.down")
-	const buttonClassDelete = getStyleAsClassName("array.child.controls.delete")
-	const controlClass = [
-		getStyleAsClassName("array.control"),
-		convertToValidClassName(controlElement.scope)
-	].join(" ")
 
 	// Util to convert dot path into slash path: eg: address.country -> /address/country
 	const route = '/' + path.split('.').join('/');
 
   	return (
-    	<div className={controlClass}>
-      		<div className={divClassNames}>{errors}</div>
-			<div className={classNames.children}>
-				{data ? (
-				range(0, data.length).map(index => {
-					const childPath = composePaths(path, `${index}`)
-					return (
-					<div key={index}>
-						<JsonFormsDispatch
-						schema={schema}
-						uischema={childUiSchema || uischema}
-						path={childPath}
-						key={childPath}
-						renderers={renderers}
-						/>
-						<div className={childControlsClass}>
-						<button
-							className={buttonClassUp}
-							aria-label={translations.upAriaLabel}
-							onClick={() => {
-							moveUp(path, index)()
-							}}
-						>
-							{translations.up}
-						</button>
-						<button
-							className={buttonClassDown}
-							aria-label={translations.downAriaLabel}
-							onClick={() => {
-							moveDown(path, index)()
-							}}
-						>
-							{translations.down}
-						</button>
-						<button
-							className={buttonClassDelete}
-							aria-label={translations.removeAriaLabel}
-							onClick={() => {
-							if (
-								window.confirm(
-								"Are you sure you wish to delete this item?"
-								)
-							) {
-								removeItems(path, [index])()
-							}
-							}}
-						>
-							{translations.removeTooltip}
-						</button>
-						</div>
-					</div>
-					)
-				})
-				) : (
-				<p>{translations.noDataMessage}</p>
-				)}
-			</div>
+    	<div>
+      		<div>{errors}</div>
 	  		<ItemGroup 
                 isBordered={true} 
                 isSeparated={true}

--- a/src/js/renderers/ArrayLayoutRenderer.js
+++ b/src/js/renderers/ArrayLayoutRenderer.js
@@ -207,13 +207,12 @@ export const ArrayControl = ( {
             >
                 { ( data )? (
                     range( 0, data.length ).map(( index ) => {
-                        const childPath = composePaths( path, `${index}` );
                         return (
                             <Item key={ index }>
 								<HStack>
 									<NavigationButtonAsItem
-										path={ `${route}/${index}` }
-										aria-label={ `Item #${index}` }
+										path={ `${ route }/${ index }` }
+										aria-label={ `Item #${ index }` }
 									>
 										<HStack justify="space-between">
 											<FlexItem>
@@ -222,7 +221,20 @@ export const ArrayControl = ( {
 										</HStack>
 									</NavigationButtonAsItem>
 									<ItemActionsMenu 
-										onEdit={ () => navigator.goTo( `${route}/${index}` ) }
+										onEdit={ () => navigator.goTo( `${ route }/${ index }` ) }
+										onRemove={ () => {
+											if (
+												window.confirm(
+													"Are you sure you wish to delete this item?"
+												)
+											) {
+												removeItems( path, [index] )()
+											}
+										} }
+										onDuplicate={() => {
+											addItem( path, data[ index ] )();
+											navigator.goTo( `${ route }/${ data.length }` );
+										} }
 									/>
 								</HStack>
                             </Item>

--- a/src/js/renderers/ArrayLayoutRenderer.js
+++ b/src/js/renderers/ArrayLayoutRenderer.js
@@ -11,7 +11,15 @@ import {
   withJsonFormsArrayControlProps
 } from "@jsonforms/react"
 
-import { chevronLeft, chevronRight, plus } from '@wordpress/icons';
+import { 
+	chevronLeft, 
+	chevronRight, 
+	plus,
+	moreVertical, 
+	edit, 
+	copy, 
+	trash 
+} from '@wordpress/icons';
 import { isRTL, __ } from '@wordpress/i18n';
 import { IconWithCurrentColor } from './NavigatorLayout/icon-with-current-color';
 import { NavigationButtonAsItem } from './NavigatorLayout/navigation-button';
@@ -21,15 +29,43 @@ import {
 	__experimentalHStack as HStack,
     __experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
+	DropdownMenu, 
+	MenuGroup, 
+	MenuItem,
 	FlexItem,
 	Button
 } from '@wordpress/components';
+
+const ItemActionsMenu = ( { onEdit, onDuplicate, onRemove } ) => (
+    <DropdownMenu icon={ moreVertical } label="Select an action">
+        { () => (
+            <>
+                <MenuGroup
+					style={ { width: 200 } }
+				>
+                    <MenuItem icon={ edit } onClick={ onEdit }>
+                        Edit
+                    </MenuItem>
+                    <MenuItem icon={ copy } onClick={ onDuplicate }>
+                        Duplicate
+                    </MenuItem>
+                </MenuGroup>
+                <MenuGroup>
+                    <MenuItem icon={ trash } onClick={ onRemove }>
+                        Remove
+                    </MenuItem>
+                </MenuGroup>
+            </>
+        ) }
+    </DropdownMenu>
+);
 
 const { convertToValidClassName } = Helpers
 
 // TODO: add new item button component
 const AddItemButton = ({ route, path, label, schema, addItem }) => {
 	const navigator = useNavigator();
+	
 	return (
 		<Button
 			aria-label={ `Add new item` }
@@ -69,6 +105,7 @@ export const ArrayControl = ( {
 	rootSchema,
 	translations
 } ) => {
+	const navigator = useNavigator();
 
   	const controlElement = uischema
   	const childUiSchema = useMemo(
@@ -173,19 +210,21 @@ export const ArrayControl = ( {
                         const childPath = composePaths( path, `${index}` );
                         return (
                             <Item key={ index }>
-                                <NavigationButtonAsItem
-                                    path={ `${route}/${index}` }
-                                    aria-label={ `Item #${index}` }
-                                >
-                                    <HStack justify="space-between">
-                                    <FlexItem>
-                                        item #{ index }
-                                    </FlexItem>
-                                    <IconWithCurrentColor
-                                        icon={ isRTL() ? chevronLeft : chevronRight }
-                                    />
-                                    </HStack>
-                                </NavigationButtonAsItem>
+								<HStack>
+									<NavigationButtonAsItem
+										path={ `${route}/${index}` }
+										aria-label={ `Item #${index}` }
+									>
+										<HStack justify="space-between">
+											<FlexItem>
+												item #{ index }
+											</FlexItem>
+										</HStack>
+									</NavigationButtonAsItem>
+									<ItemActionsMenu 
+										onEdit={ () => navigator.goTo( `${route}/${index}` ) }
+									/>
+								</HStack>
                             </Item>
                         )
                     } ) 


### PR DESCRIPTION
## Summary
- Implement the dropdown with 3 actions

| Edit  |  Duplicate | Delete  |
|---|---|---|
| ![chrome-capture-2023-6-19 (2)](https://github.com/bangank36/WP-Builder/assets/10071857/5cef4f98-1d80-43f1-b5d3-50ad704a3d89)  |  ![chrome-capture-2023-6-19 (4)](https://github.com/bangank36/WP-Builder/assets/10071857/a6370afd-40f7-4570-b61c-88fb80ce14bb) |  ![chrome-capture-2023-6-19 (3)](https://github.com/bangank36/WP-Builder/assets/10071857/f9114e31-07e5-4fec-8562-8f6c7eee2544) |

## Testing
- Checkout this branch
- Run `npm run start`
- Navigator to /address/comments screen
- Confirm the Actions works as expected


## Reference
https://github.com/bangank36/WP-Builder/issues/52