### PR TITLE
Poc/flat uischema

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -24,17 +24,6 @@ const schema = {
     },
     "nationality": {
       "type": "string",
-      "enum": [
-        "DE",
-        "IT",
-        "JP",
-        "US",
-        "RU",
-        "Other"
-      ]
-    },
-    "provideAddress": {
-      "type": "boolean"
     },
     "address": {
       "type": "object",

--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -1,91 +1,111 @@
 import React, { useState } from "react";
 import {
-  vanillaRenderers as materialRenderers,
-  vanillaCells as materialCells,
-} from "@jsonforms/vanilla-renderers";
+  materialRenderers,
+  materialCells,
+} from "@jsonforms/material-renderers";
 import { JsonForms } from "@jsonforms/react";
-import TextControl, { textControlTester } from "../renderers/Primitive/TextControl";
-import MultilineTextControl, { multilineTextControlTester } from "../renderers/Primitive/MultilineTextControl";
-import ColorPaletteTextControl, { colorPaletteControlTester } from "../renderers/Primitive/ColorPaletteControl";
-import BooleanCheckboxControl, { booleanCheckboxControlTester } from "../renderers/Primitive/BooleanCheckboxControl";
-import BooleanToggleControl, { booleanToggleControlTester } from "../renderers/Primitive/BooleanToggleControl";
-import GutenbergToggleGroupControl, { gutenbergToggleGroupTester } from "../renderers/Primitive/ToggleGroupControl";
-import GutenbergToggleGroupOneOfControl, { gutenbergToggleGroupOneOfTester } from "../renderers/Primitive/ToggleGroupOneOfControl";
-import GutenbergObjectRenderer, { gutenbergObjectControlTester } from "../renderers/ObjectRenderer";
-import GutenbergArrayRenderer, { gutenbergArrayControlTester } from "../renderers/ArrayControlRenderer";
-import PortedArrayRenderer, { portedArrayControlTester } from "../renderers/PortedArrayRenderer";
-import GutenbergNavigatorlLayoutRenderer, { gutenbergNavigatorLayoutTester } from "../renderers/NavigatorLayout";
-import GutenbergVerticalLayoutRenderer, { gutenbergVerticalLayoutTester } from "../renderers/GutenbergVerticalLayout";
 
 import {
   __experimentalGrid as Grid,
 } from '@wordpress/components';
 
 const schema = {
-  type: "object",
-  properties: {
-    address: {
-      type: 'object',
-      properties: {
-        street_address: { type: 'string' },
-        city: { type: 'string' },
-        state: { type: 'string' },
-        isOffice: { 
-          type: 'boolean',
-          description: 'Is this an office address?',
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string",
+      "minLength": 3,
+      "description": "Please enter your first name"
+    },
+    "birthDate": {
+      "type": "string",
+      "format": "date",
+      "description": "Please enter your birth date."
+    },
+    "nationality": {
+      "type": "string",
+      "enum": [
+        "DE",
+        "IT",
+        "JP",
+        "US",
+        "RU",
+        "Other"
+      ]
+    },
+    "provideAddress": {
+      "type": "boolean"
+    },
+    "address": {
+      "type": "object",
+      "properties": {
+        "street": {
+          "type": "string"
         },
-        country: {
-          type: 'object',
-          properties: {
-            name: { type: 'string' },
-          }
+        "city": {
+          "type": "string"
         },
-        gender: {
-          type: "string",
-          enum: [ "male", "female", "other" ],
-          format: 'toggle-group',
-          description: "The gender of the user"
-        },
-        oneOfEnum: {
-          type: 'string',
-          format: 'toggle-group',
-          oneOf: [
-            { const: 'foo', title: 'Foo' },
-            { const: 'bar', title: 'Bar' },
-            { const: 'foobar', title: 'FooBar' },
-          ],
-        },
-        comments: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              comment: { 
-                type: 'string',
-              },
+        "country": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "code": {
+              "type": "string",
+              "maxLength": 2
             }
-            
-          },
-        },
+          }
+        }
       }
     },
-    business: {
-      type: 'object',
-      properties: {
-        job: { type: 'string' }
+    "vegetarianOptions": {
+      "type": "object",
+      "properties": {
+        "vegan": {
+          "type": "boolean"
+        },
+        "favoriteVegetable": {
+          "type": "string",
+          "enum": [
+            "Tomato",
+            "Potato",
+            "Salad",
+            "Aubergine",
+            "Cucumber",
+            "Other"
+          ]
+        }
       }
     }
-  },
+  }
 };
 
 const uischema = {
-  type: 'NavigatorLayout',
-  elements: [
+  "type": "VerticalLayout",
+  "elements": [
     {
-      type: 'Control',
-      scope: '#',
+      "type": "HorizontalLayout",
+      "elements": [
+        {
+          "type": "Control",
+          "scope": "#"
+        },
+        {
+          "type": "Control",
+          "scope": "#/properties/address"
+        },
+        {
+          "type": "Control",
+          "scope": "#/properties/address/properties/country"
+        },
+        {
+          "type": "Control",
+          "scope": "#/properties/vegetarianOptions"
+        },
+      ]
     }
-  ],
+  ]
 }
 
 const initialData = {
@@ -103,41 +123,23 @@ const initialData = {
 // list of renderers declared outside the App component
 const renderers = [
   ...materialRenderers,
-  //register custom renderers
-  { tester: textControlTester, renderer: TextControl },
-  { tester: multilineTextControlTester, renderer: MultilineTextControl },
-  { tester: colorPaletteControlTester, renderer: ColorPaletteTextControl },
-  { tester: booleanToggleControlTester, renderer: BooleanToggleControl},
-  { tester: booleanCheckboxControlTester, renderer: BooleanCheckboxControl},
-  { tester: gutenbergToggleGroupTester, renderer: GutenbergToggleGroupControl},
-  { tester: gutenbergToggleGroupOneOfTester, renderer: GutenbergToggleGroupOneOfControl},
-  { tester: gutenbergObjectControlTester, renderer: GutenbergObjectRenderer},
-  { tester: gutenbergArrayControlTester, renderer: GutenbergArrayRenderer},
-  // { tester: portedArrayControlTester, renderer: PortedArrayRenderer},
-  { tester: gutenbergNavigatorLayoutTester, renderer: GutenbergNavigatorlLayoutRenderer},
-  { tester: gutenbergVerticalLayoutTester, renderer: GutenbergVerticalLayoutRenderer}
 ];
 
 export default function App() {
   const [data, setData] = useState(initialData);
   return (
     <>
-      <Grid columns={ 3 }>
+      <Grid>
         <JsonForms
           schema={schema}
           uischema={uischema}
-          data={data}
+          // data={data}
           renderers={renderers}
           cells={materialCells}
           onChange={({ data, _errors }) => {
             setData(data);
           }}
         />
-        <div>
-          <pre>
-          {JSON.stringify(data, null, 4)}
-          </pre>
-        </div>
       </Grid>
     </>
   );


### PR DESCRIPTION
## Summary
By splitting the layout into separate elements with nested scope, I can display the nested props into `flat` structure as seen in this screen shot
<img width="997" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/0d00f469-1a46-4d90-8b6e-b4efb5ba814d">

- Some side notes
  1. We still need a custom renderer for the object to render NavigatorButton instead of the whole control in the parent screen
  2. Have to hard code the scope so `uischema` can know which nested screens to render, though can we send the `scope` to Navigator context instead of the renderer props?

## Testing
- Checkout think branch
- Run `npm run start`

## Reference
https://github.com/bangank36/WP-Builder/issues/66