### PR TITLE
WP-Builder: Object uischema with detail option

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import {
-  vanillaRenderers as materialRenderers,
-  vanillaCells as materialCells,
-} from "@jsonforms/vanilla-renderers";
+  materialRenderers,
+  materialCells,
+} from "@jsonforms/material-renderers";
 import { JsonForms } from "@jsonforms/react";
 import TextControl, { textControlTester } from "../renderers/Primitive/TextControl";
 import MultilineTextControl, { multilineTextControlTester } from "../renderers/Primitive/MultilineTextControl";
@@ -11,7 +11,7 @@ import BooleanCheckboxControl, { booleanCheckboxControlTester } from "../rendere
 import BooleanToggleControl, { booleanToggleControlTester } from "../renderers/Primitive/BooleanToggleControl";
 import GutenbergToggleGroupControl, { gutenbergToggleGroupTester } from "../renderers/Primitive/ToggleGroupControl";
 import GutenbergToggleGroupOneOfControl, { gutenbergToggleGroupOneOfTester } from "../renderers/Primitive/ToggleGroupOneOfControl";
-import GutenbergObjectRenderer, { gutenbergObjectControlTester } from "../renderers/ObjectRenderer";
+import GutenbergObjectRenderer, { modifiedMaterialObjectControlTester } from "../renderers/ObjectRenderer";
 import GutenbergArrayRenderer, { gutenbergArrayControlTester } from "../renderers/ArrayControlRenderer";
 import PortedArrayRenderer, { portedArrayControlTester } from "../renderers/PortedArrayRenderer";
 import GutenbergNavigatorlLayoutRenderer, { gutenbergNavigatorLayoutTester } from "../renderers/NavigatorLayout";
@@ -21,72 +21,79 @@ import {
   __experimentalGrid as Grid,
 } from '@wordpress/components';
 
-const schema = {
-  type: "object",
+export const schema = {
+  type: 'object',
   properties: {
-    address: {
+    occupation: { 
       type: 'object',
       properties: {
-        street_address: { type: 'string' },
-        city: { type: 'string' },
-        state: { type: 'string' },
-        isOffice: { 
-          type: 'boolean',
-          description: 'Is this an office address?',
-        },
-        country: {
-          type: 'object',
-          properties: {
-            name: { type: 'string' },
-          }
-        },
-        gender: {
-          type: "string",
-          enum: [ "male", "female", "other" ],
-          format: 'toggle-group',
-          description: "The gender of the user"
-        },
-        oneOfEnum: {
-          type: 'string',
-          format: 'toggle-group',
-          oneOf: [
-            { const: 'foo', title: 'Foo' },
-            { const: 'bar', title: 'Bar' },
-            { const: 'foobar', title: 'FooBar' },
-          ],
-        },
-        comments: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              comment: { 
-                type: 'string',
-              },
-            }
-            
-          },
-        },
+        name: { type: 'string' },
+        years: { type: 'number' },
       }
     },
-    business: {
-      type: 'object',
-      properties: {
-        job: { type: 'string' }
-      }
-    }
+    comments: {
+      type: 'array',
+      minItems: 2,
+      maxItems: 8,
+      items: {
+        type: 'object',
+        properties: {
+          date: {
+            type: 'string',
+            format: 'date',
+          },
+          message: {
+            type: 'string',
+            maxLength: 5,
+          },
+        },
+      },
+    },
   },
+  required: ['occupation', 'nationality'],
 };
 
-const uischema = {
-  type: 'NavigatorLayout',
+export const uischema = {
+  type: 'VerticalLayout',
   elements: [
     {
       type: 'Control',
-      scope: '#',
+      scope: '#/properties/comments',
+      options: {
+        showSortButtons: true,
+        restrict: true,
+        detail: {
+          type: 'Group',
+          elements: [
+            {
+              type: 'Control',
+              scope: '#/properties/date',
+            }
+          ],
+        },
+      },
+    },
+    {
+      type: 'Control',
+      scope: '#/properties/occupation',
+      options: {
+        detail: {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'Control',
+              scope: '#/properties/name',
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/years',
+            },
+          ],
+        },
+      },
     }
   ],
-}
+};
 
 const initialData = {
   address: {
@@ -104,18 +111,18 @@ const initialData = {
 const renderers = [
   ...materialRenderers,
   //register custom renderers
-  { tester: textControlTester, renderer: TextControl },
-  { tester: multilineTextControlTester, renderer: MultilineTextControl },
-  { tester: colorPaletteControlTester, renderer: ColorPaletteTextControl },
-  { tester: booleanToggleControlTester, renderer: BooleanToggleControl},
-  { tester: booleanCheckboxControlTester, renderer: BooleanCheckboxControl},
-  { tester: gutenbergToggleGroupTester, renderer: GutenbergToggleGroupControl},
-  { tester: gutenbergToggleGroupOneOfTester, renderer: GutenbergToggleGroupOneOfControl},
-  { tester: gutenbergObjectControlTester, renderer: GutenbergObjectRenderer},
-  { tester: gutenbergArrayControlTester, renderer: GutenbergArrayRenderer},
-  // { tester: portedArrayControlTester, renderer: PortedArrayRenderer},
-  { tester: gutenbergNavigatorLayoutTester, renderer: GutenbergNavigatorlLayoutRenderer},
-  { tester: gutenbergVerticalLayoutTester, renderer: GutenbergVerticalLayoutRenderer}
+  // { tester: textControlTester, renderer: TextControl },
+  // { tester: multilineTextControlTester, renderer: MultilineTextControl },
+  // { tester: colorPaletteControlTester, renderer: ColorPaletteTextControl },
+  // { tester: booleanToggleControlTester, renderer: BooleanToggleControl},
+  // { tester: booleanCheckboxControlTester, renderer: BooleanCheckboxControl},
+  // { tester: gutenbergToggleGroupTester, renderer: GutenbergToggleGroupControl},
+  // { tester: gutenbergToggleGroupOneOfTester, renderer: GutenbergToggleGroupOneOfControl},
+  { tester: modifiedMaterialObjectControlTester, renderer: GutenbergObjectRenderer},
+  // { tester: gutenbergArrayControlTester, renderer: GutenbergArrayRenderer},
+  // // { tester: portedArrayControlTester, renderer: PortedArrayRenderer},
+  // { tester: gutenbergNavigatorLayoutTester, renderer: GutenbergNavigatorlLayoutRenderer},
+  // { tester: gutenbergVerticalLayoutTester, renderer: GutenbergVerticalLayoutRenderer}
 ];
 
 export default function App() {

--- a/src/js/renderers/ObjectRenderer.js
+++ b/src/js/renderers/ObjectRenderer.js
@@ -1,28 +1,15 @@
-import isEmpty from 'lodash/isEmpty';
+import isEmpty from "lodash/isEmpty"
 import {
   findUISchema,
   Generate,
   isObjectControl,
-  rankWith,
-} from '@jsonforms/core';
-import { 
-  withJsonFormsDetailProps,
- } from '@jsonforms/react';
-import React, { useMemo, useContext, useEffect } from 'react';
-import { Context as NavigatorContext } from '../component/context';
-import { resolvePathToRoute } from './util';
+  rankWith
+} from "@jsonforms/core"
+import { JsonFormsDispatch, withJsonFormsDetailProps } from "@jsonforms/react"
+import { Hidden } from "@mui/material"
+import React, { useMemo } from "react"
 
-import { chevronLeft, chevronRight } from '@wordpress/icons';
-import { isRTL, __ } from '@wordpress/i18n';
-import { IconWithCurrentColor } from './NavigatorLayout/icon-with-current-color';
-import { NavigationButtonAsItem } from './NavigatorLayout/navigation-button';
-
-import {
-	__experimentalHStack as HStack,
-	FlexItem,
-} from '@wordpress/components';
-
-export const GutenbergObjectRenderer = ({
+export const MaterialObjectRenderer = ({
   renderers,
   cells,
   uischemas,
@@ -32,7 +19,7 @@ export const GutenbergObjectRenderer = ({
   visible,
   enabled,
   uischema,
-  rootSchema,
+  rootSchema
 }) => {
   const detailUiSchema = useMemo(
     () =>
@@ -43,67 +30,28 @@ export const GutenbergObjectRenderer = ({
         path,
         () =>
           isEmpty(path)
-            ? Generate.uiSchema(schema, 'VerticalLayout')
-            : { ...Generate.uiSchema(schema, 'Group'), label },
+            ? Generate.uiSchema(schema, "VerticalLayout")
+            : { ...Generate.uiSchema(schema, "Group"), label },
         uischema,
         rootSchema
       ),
     [uischemas, schema, uischema.scope, path, label, uischema, rootSchema]
-  );
-
-  const route = resolvePathToRoute(path);
-
-  const [screenContent, setScreenContent] = useContext(NavigatorContext);
-
-  //UseEffect to fix the issue Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate.
-  useEffect( () => {
-    if ( !route ) {
-      return;
-    }
-    // Use the callback since the new state is based on the previous state
-    setScreenContent(prevScreenContent => ( {
-      ...prevScreenContent,
-      [ route ]: {
-        rendererProps: ( {
-          renderers,
-          cells,
-          uischemas,
-          schema,
-          label,
-          path,
-          visible,
-          enabled,
-          uischema: detailUiSchema,
-          rootSchema,
-        } ),
-        label: detailUiSchema.label,
-        path: path
-      }
-    } ) )
-  }, [route] )
-
-  return !visible ? null : (
-    <>
-      <NavigationButtonAsItem
-        path={route}
-        aria-label={detailUiSchema.label}
-      >
-        <HStack justify="space-between">
-          <FlexItem>
-            {detailUiSchema.label}
-          </FlexItem>
-          <IconWithCurrentColor
-            icon={isRTL() ? chevronLeft : chevronRight}
-          />
-        </HStack>
-      </NavigationButtonAsItem>
-    </>
   )
-};
+  return (
+    <Hidden xsUp={!visible}>
+      <JsonFormsDispatch
+        visible={visible}
+        enabled={enabled}
+        schema={schema}
+        uischema={detailUiSchema}
+        path={path}
+        renderers={renderers}
+        cells={cells}
+      />
+    </Hidden>
+  )
+}
 
-export const gutenbergObjectControlTester = rankWith(
-  9,
-  isObjectControl
-);
+export const modifiedMaterialObjectControlTester = rankWith(3, isObjectControl)
 
-export default withJsonFormsDetailProps(GutenbergObjectRenderer);
+export default withJsonFormsDetailProps(MaterialObjectRenderer)


### PR DESCRIPTION
## Summary
- This PR is used for testing the `detail` options for Object Control with mui, turns out jsonforms support `detail` layout for Object out of the box
- We can change how individual control is render using the uischema within `detail`
- Given uischema can define how object is rendered, for example the order of controls

```
{
      type: 'Control',
      scope: '#/properties/occupation',
      options: {
        detail: {
          type: 'VerticalLayout',
          elements: [
            {
              type: 'Control',
              scope: '#/properties/name',
            },
            {
              type: 'Control',
              scope: '#/properties/years',
            },
          ],
        },
      },
    }
```

## Reference
https://github.com/bangank36/WP-Builder/issues/69