### PR TITLE
WP-Builder: Feat/object detail label

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -72,8 +72,14 @@ const schema = {
     business: {
       type: 'object',
       properties: {
-        job: { type: 'string' }
-      }
+        job: {
+          type: 'string',
+        },
+        experience: {
+          type: 'string',
+          maxLength: 5,
+        },
+      },
     }
   },
 };
@@ -83,8 +89,23 @@ const uischema = {
   elements: [
     {
       type: 'Control',
-      scope: '#',
-    }
+      scope: '#/properties/business',
+      options: {
+        detail: {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'Control',  
+              scope: '#/properties/job',
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/experience',
+            }
+          ]
+        }
+      }
+    },
   ],
 }
 

--- a/src/js/renderers/ObjectRenderer.js
+++ b/src/js/renderers/ObjectRenderer.js
@@ -1,12 +1,12 @@
 import isEmpty from 'lodash/isEmpty';
 import {
-  findUISchema,
-  Generate,
-  isObjectControl,
-  rankWith,
+	findUISchema,
+	Generate,
+	isObjectControl,
+	rankWith,
 } from '@jsonforms/core';
 import { 
-  withJsonFormsDetailProps,
+  	withJsonFormsDetailProps,
  } from '@jsonforms/react';
 import React, { useMemo, useContext, useEffect } from 'react';
 import { Context as NavigatorContext } from '../component/context';
@@ -23,16 +23,16 @@ import {
 } from '@wordpress/components';
 
 export const GutenbergObjectRenderer = ({
-  renderers,
-  cells,
-  uischemas,
-  schema,
-  label,
-  path,
-  visible,
-  enabled,
-  uischema,
-  rootSchema,
+	renderers,
+	cells,
+	uischemas,
+	schema,
+	label,
+	path,
+	visible,
+	enabled,
+	uischema,
+	rootSchema,
 }) => {
   const detailUiSchema = useMemo(
     () =>
@@ -51,9 +51,9 @@ export const GutenbergObjectRenderer = ({
     [uischemas, schema, uischema.scope, path, label, uischema, rootSchema]
   );
 
-  const route = resolvePathToRoute(path);
+  const route = resolvePathToRoute( path );
 
-  const [screenContent, setScreenContent] = useContext(NavigatorContext);
+  const [ screenContent, setScreenContent ] = useContext( NavigatorContext );
 
   //UseEffect to fix the issue Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate.
   useEffect( () => {
@@ -65,18 +65,18 @@ export const GutenbergObjectRenderer = ({
       ...prevScreenContent,
       [ route ]: {
         rendererProps: ( {
-          renderers,
-          cells,
-          uischemas,
-          schema,
-          label,
-          path,
-          visible,
-          enabled,
-          uischema: detailUiSchema,
-          rootSchema,
+			renderers,
+			cells,
+			uischemas,
+			schema,
+			label,
+			path,
+			visible,
+			enabled,
+			uischema: detailUiSchema,
+			rootSchema,
         } ),
-        label: detailUiSchema.label,
+        label: detailUiSchema.label || label,
         path: path
       }
     } ) )
@@ -84,26 +84,26 @@ export const GutenbergObjectRenderer = ({
 
   return !visible ? null : (
     <>
-      <NavigationButtonAsItem
-        path={route}
-        aria-label={detailUiSchema.label}
-      >
-        <HStack justify="space-between">
-          <FlexItem>
-            {detailUiSchema.label}
-          </FlexItem>
-          <IconWithCurrentColor
-            icon={isRTL() ? chevronLeft : chevronRight}
-          />
-        </HStack>
-      </NavigationButtonAsItem>
+		<NavigationButtonAsItem
+			path={ route }
+			aria-label={ detailUiSchema.label | label }
+		>
+			<HStack justify="space-between">
+			<FlexItem>
+				{ detailUiSchema.label || label }
+			</FlexItem>
+			<IconWithCurrentColor
+				icon={ isRTL() ? chevronLeft : chevronRight }
+			/>
+			</HStack>
+      	</NavigationButtonAsItem>
     </>
   )
 };
 
 export const gutenbergObjectControlTester = rankWith(
-  9,
-  isObjectControl
+	9,
+	isObjectControl
 );
 
 export default withJsonFormsDetailProps(GutenbergObjectRenderer);

--- a/src/js/renderers/ObjectRenderer.js
+++ b/src/js/renderers/ObjectRenderer.js
@@ -36,19 +36,19 @@ export const GutenbergObjectRenderer = ({
 }) => {
   const detailUiSchema = useMemo(
     () =>
-      findUISchema(
-        uischemas,
-        schema,
-        uischema.scope,
-        path,
-        () =>
-          isEmpty(path)
-            ? Generate.uiSchema(schema, 'VerticalLayout')
-            : { ...Generate.uiSchema(schema, 'Group'), label },
-        uischema,
-        rootSchema
-      ),
-    [uischemas, schema, uischema.scope, path, label, uischema, rootSchema]
+		findUISchema(
+			uischemas,
+			schema,
+			uischema.scope,
+			path,
+			() =>
+			isEmpty(path)
+				? Generate.uiSchema(schema, 'VerticalLayout')
+				: { ...Generate.uiSchema(schema, 'Group'), label },
+			uischema,
+			rootSchema
+		),
+    [ uischemas, schema, uischema.scope, path, label, uischema, rootSchema ]
   );
 
   const route = resolvePathToRoute( path );


### PR DESCRIPTION
## Summary
- By default VerticalLayout did not require a label, therefore if the `detail` uischema for object control is VerticalLayout, the label will be empty, make the NavigatorButton text empty
- This PR use the renderer label in case the `detailUiSchema` has no label
<img width="243" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/fe76c2ca-3ae3-41d0-b42b-e53566370965">

## Reference
#70 