### PR TITLE
WP-Builder: Feat/amend color picker

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -27,12 +27,18 @@ const schema = {
     address: {
       type: 'object',
       properties: {
-        street_address: { type: 'string' },
+        street_address: { 
+          type: 'string',
+        },
         city: { type: 'string' },
         state: { type: 'string' },
         isOffice: { 
           type: 'boolean',
           description: 'Is this an office address?',
+        },
+        roofColor: {
+          type: 'string',
+          format: 'color',
         },
         country: {
           type: 'object',
@@ -46,21 +52,20 @@ const schema = {
           format: 'toggle-group',
           description: "The gender of the user"
         },
-        oneOfEnum: {
+        race: {
           type: 'string',
           format: 'toggle-group',
           oneOf: [
-            { const: 'foo', title: 'Foo' },
-            { const: 'bar', title: 'Bar' },
-            { const: 'foobar', title: 'FooBar' },
+            { const: 'asian', title: 'Asian' },
+            { const: 'latin', title: 'Latin' },
           ],
         },
-        comments: {
+        businessHours: {
           type: 'array',
           items: {
             type: 'object',
             properties: {
-              comment: { 
+              date: { 
                 type: 'string',
               },
             }
@@ -88,30 +93,14 @@ const uischema = {
   type: 'NavigatorLayout',
   elements: [
     {
-      type: 'Control',
-      scope: '#/properties/business',
-      options: {
-        detail: {
-          type: 'VerticalLayout',
-          elements: [
-            {
-              type: 'Control',  
-              scope: '#/properties/job',
-            },
-            {
-              type: 'Control',
-              scope: '#/properties/experience',
-            }
-          ]
-        }
-      }
-    },
+      type: "Control",
+      scope: "#",
+    }
   ],
 }
 
 const initialData = {
   address: {
-    isOffice: false,
     gender: "other",
     comments: [{
       comment: 'test'
@@ -147,7 +136,7 @@ export default function App() {
         <JsonForms
           schema={schema}
           uischema={uischema}
-          data={data}
+          // data={data}
           renderers={renderers}
           cells={materialCells}
           onChange={({ data, _errors }) => {

--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -136,7 +136,7 @@ export default function App() {
         <JsonForms
           schema={schema}
           uischema={uischema}
-          // data={data}
+          data={data}
           renderers={renderers}
           cells={materialCells}
           onChange={({ data, _errors }) => {

--- a/src/js/renderers/ArrayControlRenderer.js
+++ b/src/js/renderers/ArrayControlRenderer.js
@@ -121,23 +121,7 @@ export const GutenbergArrayRenderer = (ownControlProps) => {
                 }),
                 label: detailUiSchema.label,
                 path: path
-            },
-			[ `${route}/new` ]: {
-                rendererProps: ( {    
-                    renderers,
-                    cells,
-                    uischemas,
-                    schema,
-                    label,
-                    path: composePaths(path, `${0}`),
-                    visible,
-                    enabled,
-                    uischema: childUiSchema,
-                    rootSchema,
-                } ),
-                label: detailUiSchema.label,
-                path: path
-            },
+            }
         }))
     }, [ route ] )
 

--- a/src/js/renderers/Primitive/BooleanToggleControl.js
+++ b/src/js/renderers/Primitive/BooleanToggleControl.js
@@ -3,11 +3,9 @@ import { withJsonFormsControlProps } from "@jsonforms/react";
 import { rankWith, isBooleanControl } from "@jsonforms/core";
 import {
 	__experimentalHStack as HStack,
-	__experimentalSpacer as Spacer,
 	FormToggle,
 	Tooltip,	
     FlexItem,
-	HorizontalRule
 } from '@wordpress/components';
 
 const ToggleControl = (props) => {
@@ -45,9 +43,6 @@ const ToggleControl = (props) => {
 					/>
 				</FlexItem>
 			</HStack>
-			<Spacer marginTop={2} marginBottom={0}>
-				<HorizontalRule />
-			</Spacer>
 		</>
   	)
 };

--- a/src/js/renderers/Primitive/ColorPaletteControl.js
+++ b/src/js/renderers/Primitive/ColorPaletteControl.js
@@ -6,12 +6,16 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalZStack as ZStack,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
+  	__experimentalSpacer as Spacer,
 	ColorIndicator,
 	Flex,
 	FlexItem,
 	Dropdown,
 	Button,
-  ColorPalette, SlotFillProvider, Popover
+	ColorPalette, 
+	SlotFillProvider, 
+	Popover,
+	HorizontalRule
 } from '@wordpress/components';
 
 const LabeledColorIndicators = ( { indicators, label } ) => (
@@ -23,74 +27,87 @@ const LabeledColorIndicators = ( { indicators, label } ) => (
 				</Flex>
 			) ) }
 		</ZStack>
-		<FlexItem
-			className="block-editor-panel-color-gradient-settings__color-name"
-			title={ label }
-		>
-			{ label }
-		</FlexItem>
 	</HStack>
 );
 
 const TextControl = (props) => {
-  const {
-    id,
-    description,
-    errors,
-    label,
-    uischema,
-    path,
-    visible,
-    required,
-    config,
-    data,
-    input,
-    handleChange
-  } = props;
+  	const {
+		id,
+		description,
+		errors,
+		label,
+		uischema,
+		path,
+		visible,
+		required,
+		config,
+		data,
+		input,
+		handleChange
+  	} = props;
   
-  const colors = uischema.options.colors || [
-    { name: 'red', color: '#f00' },
-    { name: 'white', color: '#fff' },
-    { name: 'blue', color: '#00f' },
-  ];
+  	const colors = uischema.options.colors || [
+		{ name: 'red', color: '#f00' },
+		{ name: 'white', color: '#fff' },
+		{ name: 'blue', color: '#00f' },
+  	];
 
   return ( 
     <>
-      <Dropdown
-        popoverProps={ {
-          placement: 'left-start',
-          offset: 36,
-          shift: true,
-        } }
-        className="my-container-class-name"
-        contentClassName="my-dropdown-content-classname"
-        renderToggle={ ( { isOpen, onToggle } ) => (
-          <Button
-            onClick={ onToggle }
-            aria-expanded={ isOpen }
-          >
-            <LabeledColorIndicators
-              indicators={ [ data ] }
-              label={ label }
-            />
-          </Button>
-        ) }
-        renderContent={ () => (
-          <DropdownContentWrapper paddingSize="none">
-            <SlotFillProvider>
-              <ColorPalette
-                colors={ colors }
-                value={ data }
-                onChange={ ( value ) => 
-                  handleChange(path, value === '' ? undefined : value)
-                }
-              />
-              <Popover.Slot />
-            </SlotFillProvider>
-          </DropdownContentWrapper>
-        ) }
-      />
-      
+        <HStack justify="space-between">
+          	<FlexItem>
+				{ description ? (
+					<Tooltip text={ description }>
+						<label htmlFor={ id }>
+						{ label }
+						</label>
+					</Tooltip>
+				) : ( 
+					<label htmlFor={ id }>
+					{ label }
+					</label> 
+				) }
+          	</FlexItem>
+          	<FlexItem>
+				<Dropdown
+					popoverProps={ {
+						placement: 'left-start',
+						offset: 36,
+						shift: true,
+					} }
+					className="my-container-class-name"
+					contentClassName="my-dropdown-content-classname"
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<Button
+							onClick={ onToggle }
+							aria-expanded={ isOpen }
+						>
+							<LabeledColorIndicators
+								indicators={ [ data ] }
+								label={ label }
+							/>
+						</Button>
+				) }
+				renderContent={ () => (
+					<DropdownContentWrapper paddingSize="none">
+						<SlotFillProvider>
+							<ColorPalette
+								colors={ colors }
+								value={ data }
+								onChange={ ( value ) => 
+									handleChange( path, value === '' ? undefined : value )
+								}
+							/>
+							<Popover.Slot />
+						</SlotFillProvider>
+					</DropdownContentWrapper>
+				) }
+				/>
+          	</FlexItem>
+        </HStack>
+        <Spacer marginTop={ 1 } marginBottom={ 1 }>
+          	<HorizontalRule />
+        </Spacer>
     </>
   )
 };
@@ -112,3 +129,5 @@ export const colorPaletteControlTester = rankWith(
 );
 
 export default withJsonFormsControlProps(TextControl);
+
+//or(formatIs('date-time'), optionIs('format', 'date-time'))

--- a/src/js/renderers/Primitive/ColorPaletteControl.js
+++ b/src/js/renderers/Primitive/ColorPaletteControl.js
@@ -1,21 +1,26 @@
 import React from "react";
-import isEmpty from 'lodash/isEmpty';
 import { withJsonFormsControlProps } from "@jsonforms/react";
-import { rankWith, isStringControl, and, optionIs } from "@jsonforms/core";
+import { 
+	rankWith, 
+	isStringControl, 
+	and, 
+	or, 
+	optionIs,
+	formatIs
+} from "@jsonforms/core";
 import {
 	__experimentalHStack as HStack,
 	__experimentalZStack as ZStack,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
-  	__experimentalSpacer as Spacer,
 	ColorIndicator,
 	Flex,
 	FlexItem,
 	Dropdown,
 	Button,
 	ColorPalette, 
+	ColorPicker,
 	SlotFillProvider, 
 	Popover,
-	HorizontalRule
 } from '@wordpress/components';
 
 const LabeledColorIndicators = ( { indicators, label } ) => (
@@ -34,100 +39,85 @@ const TextControl = (props) => {
   	const {
 		id,
 		description,
-		errors,
 		label,
 		uischema,
 		path,
-		visible,
-		required,
-		config,
 		data,
-		input,
 		handleChange
   	} = props;
   
-  	const colors = uischema.options.colors || [
-		{ name: 'red', color: '#f00' },
-		{ name: 'white', color: '#fff' },
-		{ name: 'blue', color: '#00f' },
-  	];
+  	const colors = uischema.options?.colors;
 
-  return ( 
-    <>
-        <HStack justify="space-between">
-          	<FlexItem>
-				{ description ? (
-					<Tooltip text={ description }>
+	return ( 
+		<>
+			<HStack justify="space-between">
+				<FlexItem>
+					{ description ? (
+						<Tooltip text={ description }>
+							<label htmlFor={ id }>
+							{ label }
+							</label>
+						</Tooltip>
+					) : ( 
 						<label htmlFor={ id }>
 						{ label }
-						</label>
-					</Tooltip>
-				) : ( 
-					<label htmlFor={ id }>
-					{ label }
-					</label> 
-				) }
-          	</FlexItem>
-          	<FlexItem>
-				<Dropdown
-					popoverProps={ {
-						placement: 'left-start',
-						offset: 36,
-						shift: true,
-					} }
-					className="my-container-class-name"
-					contentClassName="my-dropdown-content-classname"
-					renderToggle={ ( { isOpen, onToggle } ) => (
-						<Button
-							onClick={ onToggle }
-							aria-expanded={ isOpen }
-						>
-							<LabeledColorIndicators
-								indicators={ [ data ] }
-								label={ label }
-							/>
-						</Button>
-				) }
-				renderContent={ () => (
-					<DropdownContentWrapper paddingSize="none">
-						<SlotFillProvider>
-							<ColorPalette
-								colors={ colors }
-								value={ data }
-								onChange={ ( value ) => 
-									handleChange( path, value === '' ? undefined : value )
+						</label> 
+					) }
+				</FlexItem>
+				<FlexItem>
+					<Dropdown
+						popoverProps={ {
+							placement: 'left-start',
+							offset: 36,
+							shift: true,
+						} }
+						className="my-container-class-name"
+						contentClassName="my-dropdown-content-classname"
+						renderToggle={ ( { isOpen, onToggle } ) => (
+							<Button
+								onClick={ onToggle }
+								aria-expanded={ isOpen }
+							>
+								<LabeledColorIndicators
+									indicators={ [ data ] }
+									label={ label }
+								/>
+							</Button>
+					) }
+					renderContent={ () => (
+						<DropdownContentWrapper paddingSize="none">
+							<SlotFillProvider>
+								{
+									!colors || colors.length === 0 ? (
+										<ColorPicker 
+											onChange={ ( value ) => 
+												handleChange( path, value === '' ? undefined : value )
+											} 
+										/>
+									) : (
+										<ColorPalette
+											colors={ colors }
+											value={ data }
+											onChange={ ( value ) => 
+												handleChange( path, value === '' ? undefined : value )
+											}
+										/>
+									)
 								}
-							/>
-							<Popover.Slot />
-						</SlotFillProvider>
-					</DropdownContentWrapper>
-				) }
-				/>
-          	</FlexItem>
-        </HStack>
-        <Spacer marginTop={ 1 } marginBottom={ 1 }>
-          	<HorizontalRule />
-        </Spacer>
-    </>
-  )
+								<Popover.Slot />
+							</SlotFillProvider>
+						</DropdownContentWrapper>
+					) }
+					/>
+				</FlexItem>
+			</HStack>
+		</>
+	)
 };
-
-  const optionIsNotEmpty =
-  (optionName) =>
-  (uischema) => {
-    if (isEmpty(uischema)) {
-      return false;
-    }
-
-    const options = uischema.options;
-    return !isEmpty(options) && !isEmpty(options[optionName]);
-  };
 
 export const colorPaletteControlTester = rankWith(
   6, //increase rank as needed
-  and(isStringControl, optionIs('format', 'color'), optionIsNotEmpty('colors'))
+  and(isStringControl,or(formatIs('color'), optionIs('format', 'color')))
 );
 
 export default withJsonFormsControlProps(TextControl);
-
-//or(formatIs('date-time'), optionIs('format', 'date-time'))


### PR DESCRIPTION
## Summary
- Update label position of the color picker to move label on the left
- Update renderer logic to accept schema `format:color`
![chrome-capture-2023-6-24](https://github.com/bangank36/WP-Builder/assets/10071857/32dd5aa1-42ed-4fd6-b7a8-22d76c2f861c)

## Reference
https://github.com/bangank36/WP-Builder/issues/31
#8 