### PR TITLE
WP-Builder: Feat/matrix control renderer

### DIFF
--- a/src/js/renderers/Primitive/AlignmentMatrixControl.js
+++ b/src/js/renderers/Primitive/AlignmentMatrixControl.js
@@ -1,20 +1,22 @@
 import React from "react";
 import { withJsonFormsControlProps } from "@jsonforms/react";
-import { rankWith, isStringControl } from "@jsonforms/core";
 import { 
-	__experimentalAlignmentMatrixControl as AlignmentMatrixControl,
-    __experimentalVStack as VStack,
-	__experimentalHStack as HStack,
-	FormToggle,
+	rankWith, 
+	isStringControl,
+	and,
+	optionIs 
+} from "@jsonforms/core";
+import { 
+	Button,
+	Popover,
 	Tooltip,	
     FlexItem,
-	__experimentalSpacer as Spacer,
-
-	__experimentalDropdownContentWrapper as DropdownContentWrapper,
 	Dropdown,
-	Button,
 	SlotFillProvider, 
-	Popover,
+	__experimentalHStack as HStack,
+	__experimentalSpacer as Spacer,
+	__experimentalDropdownContentWrapper as DropdownContentWrapper,
+	__experimentalAlignmentMatrixControl as AlignmentMatrixControl,
 } from '@wordpress/components';
 
 const AlignmentMatrixControlRenderer = ( props ) => {
@@ -27,65 +29,68 @@ const AlignmentMatrixControlRenderer = ( props ) => {
 		handleChange
 	} = props;
   
-  return ( 
-    <>
-		<Spacer paddingY={ 2 } marginBottom={ 0 }>
-			<HStack justify="space-between">
-				<FlexItem>
-				{ description ? (
-					<Tooltip text={ description }>
-					<label htmlFor={ id }>
-						{ label }
-					</label>
-				</Tooltip>
-				) : ( 
-					<label htmlFor={ id }>
-						{ label }
-					</label> 
-				) }
-				</FlexItem>
-				<FlexItem>
-					<Dropdown
-						popoverProps={ {
-							placement: 'left-start',
-							offset: 36,
-							shift: true,
-						} }
-						className="my-container-class-name"
-						contentClassName="my-dropdown-content-classname"
-						renderToggle={ ( { isOpen, onToggle } ) => (
-							<Button
-								onClick={ onToggle }
-								aria-expanded={ isOpen }
-								icon={ 
-									<AlignmentMatrixControl.Icon
-										value = { data }
-									/>  
-								}
-							/>
-						) }
-						renderContent={ () => (
-							<DropdownContentWrapper paddingSize="none">
-								<SlotFillProvider>
-									<AlignmentMatrixControl
-										value = { data }
-										onChange = { ( value ) => handleChange( path, value ) }
-									/>
-									<Popover.Slot />
-								</SlotFillProvider>
-							</DropdownContentWrapper>
-						) }
-					/>
-				</FlexItem>
-			</HStack>
-		</Spacer>
-	</>
-  )
+  	return ( 
+		<>
+			<Spacer paddingY={ 2 } marginBottom={ 0 }>
+				<HStack justify="space-between">
+					<FlexItem>
+					{ description ? (
+						<Tooltip text={ description }>
+						<label htmlFor={ id }>
+							{ label }
+						</label>
+					</Tooltip>
+					) : ( 
+						<label htmlFor={ id }>
+							{ label }
+						</label> 
+					) }
+					</FlexItem>
+					<FlexItem>
+						<Dropdown
+							popoverProps={ {
+								placement: 'left-start',
+								offset: 36,
+								shift: true,
+							} }
+							className="my-container-class-name"
+							contentClassName="my-dropdown-content-classname"
+							renderToggle={ ( { isOpen, onToggle } ) => (
+								<Button
+									onClick={ onToggle }
+									aria-expanded={ isOpen }
+									icon={ 
+										<AlignmentMatrixControl.Icon
+											value = { data }
+										/>  
+									}
+								/>
+							) }
+							renderContent={ () => (
+								<DropdownContentWrapper paddingSize="none">
+									<SlotFillProvider>
+										<AlignmentMatrixControl
+											value = { data }
+											onChange = { ( value ) => handleChange( path, value ) }
+										/>
+										<Popover.Slot />
+									</SlotFillProvider>
+								</DropdownContentWrapper>
+							) }
+						/>
+					</FlexItem>
+				</HStack>
+			</Spacer>
+		</>
+  	)
 };
 
 export const alignmentMatrixControlTester = rankWith(
 	5, //increase rank as needed
-	isStringControl
+	and(
+		isStringControl,
+		optionIs('format', 'alignment-matrix')
+	)
 );
 
 export default withJsonFormsControlProps( AlignmentMatrixControlRenderer );

--- a/src/js/renderers/Primitive/AlignmentMatrixControl.js
+++ b/src/js/renderers/Primitive/AlignmentMatrixControl.js
@@ -1,0 +1,91 @@
+import React from "react";
+import { withJsonFormsControlProps } from "@jsonforms/react";
+import { rankWith, isStringControl } from "@jsonforms/core";
+import { 
+	__experimentalAlignmentMatrixControl as AlignmentMatrixControl,
+    __experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	FormToggle,
+	Tooltip,	
+    FlexItem,
+	__experimentalSpacer as Spacer,
+
+	__experimentalDropdownContentWrapper as DropdownContentWrapper,
+	Dropdown,
+	Button,
+	SlotFillProvider, 
+	Popover,
+} from '@wordpress/components';
+
+const AlignmentMatrixControlRenderer = ( props ) => {
+	const {
+		id,
+		description,
+		label,
+		path,
+		data,
+		handleChange
+	} = props;
+  
+  return ( 
+    <>
+		<Spacer paddingY={ 2 } marginBottom={ 0 }>
+			<HStack justify="space-between">
+				<FlexItem>
+				{ description ? (
+					<Tooltip text={ description }>
+					<label htmlFor={ id }>
+						{ label }
+					</label>
+				</Tooltip>
+				) : ( 
+					<label htmlFor={ id }>
+						{ label }
+					</label> 
+				) }
+				</FlexItem>
+				<FlexItem>
+					<Dropdown
+						popoverProps={ {
+							placement: 'left-start',
+							offset: 36,
+							shift: true,
+						} }
+						className="my-container-class-name"
+						contentClassName="my-dropdown-content-classname"
+						renderToggle={ ( { isOpen, onToggle } ) => (
+							<Button
+								onClick={ onToggle }
+								aria-expanded={ isOpen }
+								icon={ 
+									<AlignmentMatrixControl.Icon
+										value = { data }
+									/>  
+								}
+							/>
+						) }
+						renderContent={ () => (
+							<DropdownContentWrapper paddingSize="none">
+								<SlotFillProvider>
+									<AlignmentMatrixControl
+										value = { data }
+										onChange = { ( value ) => handleChange( path, value ) }
+									/>
+									<Popover.Slot />
+								</SlotFillProvider>
+							</DropdownContentWrapper>
+						) }
+					/>
+				</FlexItem>
+			</HStack>
+		</Spacer>
+	</>
+  )
+};
+
+export const alignmentMatrixControlTester = rankWith(
+	5, //increase rank as needed
+	isStringControl
+);
+
+export default withJsonFormsControlProps( AlignmentMatrixControlRenderer );


### PR DESCRIPTION
## Summary
- Implement AlignmentMatrix in Dropdown, the control is `string` and can only rendered using uischema `options`
```
{
          type: 'Control',
          scope: '#/properties/alignment',
          options: {
            format: 'alignment-matrix',
          }
        }
```

<img width="361" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/befe34f8-d4b3-452a-b6ba-e2c634565cb7">

## Reference
#77 
#3 