### PR TITLE
WP-Builder: Introduce new Horizontal layout

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -17,6 +17,7 @@ import GutenbergArrayRenderer, { gutenbergArrayControlTester } from "../renderer
 import PortedArrayRenderer, { portedArrayControlTester } from "../renderers/PortedArrayRenderer";
 import GutenbergNavigatorlLayoutRenderer, { gutenbergNavigatorLayoutTester } from "../renderers/NavigatorLayout";
 import GutenbergVerticalLayoutRenderer, { gutenbergVerticalLayoutTester } from "../renderers/GutenbergVerticalLayout";
+import GutenbergHorizontalLayoutRenderer, { gutenbergHorizontalLayoutTester } from "../renderers/GutenbergHorizontalLayout";
 
 import {
   __experimentalGrid as Grid,
@@ -95,13 +96,19 @@ const schema = {
 };
 
 const uischema = {
-  type: 'NavigatorLayout',
-  elements: [
+  "type": "HorizontalLayout",
+  "elements": [
     {
-      type: "Control",
-      scope: "#",
+      "type": "Control",
+      "label": "Name",
+      "scope": "#/properties/business/properties/job"
+    },
+    {
+      "type": "Control",
+      "label": "Birth Date",
+      "scope": "#/properties/business/properties/experience"
     }
-  ],
+  ]
 }
 
 const initialData = {
@@ -131,7 +138,8 @@ const renderers = [
   { tester: gutenbergArrayControlTester, renderer: GutenbergArrayRenderer},
   // { tester: portedArrayControlTester, renderer: PortedArrayRenderer},
   { tester: gutenbergNavigatorLayoutTester, renderer: GutenbergNavigatorlLayoutRenderer},
-  { tester: gutenbergVerticalLayoutTester, renderer: GutenbergVerticalLayoutRenderer}
+  { tester: gutenbergVerticalLayoutTester, renderer: GutenbergVerticalLayoutRenderer},
+  { tester: gutenbergHorizontalLayoutTester, renderer: GutenbergHorizontalLayoutRenderer}
 ];
 
 export default function App() {

--- a/src/js/renderers/GutenbergHorizontalLayout.js
+++ b/src/js/renderers/GutenbergHorizontalLayout.js
@@ -4,15 +4,15 @@ import { GutenbergLayoutRenderer } from "./LayoutRenderer";
 import { withJsonFormsLayoutProps } from "@jsonforms/react";
 
 /**
- * Default tester for a vertical layout.
+ * Default tester for a Horizontal layout.
  * @type {RankedTester}
  */
-export const gutenbergVerticalLayoutTester = rankWith(
+export const gutenbergHorizontalLayoutTester = rankWith(
   	4,
-  	uiTypeIs("VerticalLayout")
+  	uiTypeIs("HorizontalLayout")
 )
 
-export const GutenbergVerticalLayoutRenderer = ( {
+export const GutenbergHorizontalLayoutRenderer = ( {
 	uischema,
 	schema,
 	path,
@@ -21,13 +21,13 @@ export const GutenbergVerticalLayoutRenderer = ( {
 	renderers,
 	cells
 } ) => {
-  	const verticalLayout = uischema
+  	const HorizontalLayout = uischema
   	const childProps = {
-		elements: verticalLayout.elements,
+		elements: HorizontalLayout.elements,
 		schema,
 		path,
 		enabled,
-		direction: "column",
+		direction: "row",
 		visible
 	}
 
@@ -40,4 +40,4 @@ export const GutenbergVerticalLayoutRenderer = ( {
 	)
 }
 
-export default withJsonFormsLayoutProps( GutenbergVerticalLayoutRenderer )
+export default withJsonFormsLayoutProps( GutenbergHorizontalLayoutRenderer )

--- a/src/js/renderers/LayoutRenderer.js
+++ b/src/js/renderers/LayoutRenderer.js
@@ -4,6 +4,7 @@ import { getAjv } from "@jsonforms/core";
 import { JsonFormsDispatch, useJsonForms } from "@jsonforms/react";
 import {
     __experimentalGrid as Grid,
+    __experimentalView as View,
 } from '@wordpress/components';
 
 export const renderLayoutElements = (
@@ -15,7 +16,7 @@ export const renderLayoutElements = (
     cells
 ) => {
     return elements.map( (child, index) => (
-        <Grid key={ `${ path }-${ index }` }>
+        <View key={ `${ path }-${ index }` }>
             <JsonFormsDispatch
                 uischema={ child }
                 schema={ schema }
@@ -24,7 +25,7 @@ export const renderLayoutElements = (
                 renderers={ renderers }
                 cells={ cells }
             />
-        </Grid>
+        </View>
     ) )
 }
 
@@ -45,6 +46,7 @@ const LayoutRendererComponent = ( {
             !visible ? null : (
                 <Grid
                     gap={ direction === "row" ? 2 : 0 }
+                    columns={ direction === "row" ? elements.length : 1 }
                 >
                 { renderLayoutElements(
                     elements,
@@ -60,7 +62,7 @@ const LayoutRendererComponent = ( {
     }
 }
 export const GutenbergLayoutRenderer = React.memo(
-  LayoutRendererComponent
+    LayoutRendererComponent
 )
 
 // TODO fix @typescript-eslint/ban-types


### PR DESCRIPTION
## Summary
- Introduce new HorizontalLayout using Gutenberg Grid component where the number of columns are calculated based on number of `elements`

<img width="346" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/675772ef-0779-4df1-8335-d49ad6e61a57">


## Reference
https://github.com/bangank36/WP-Builder/issues/62
#3 