### PR TITLE
WP-Builder: Introduce new Select control for enum

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -12,6 +12,7 @@ import BooleanCheckboxControl, { booleanCheckboxControlTester } from "../rendere
 import BooleanToggleControl, { booleanToggleControlTester } from "../renderers/Primitive/BooleanToggleControl";
 import GutenbergToggleGroupControl, { gutenbergToggleGroupTester } from "../renderers/Primitive/ToggleGroupControl";
 import GutenbergToggleGroupOneOfControl, { gutenbergToggleGroupOneOfTester } from "../renderers/Primitive/ToggleGroupOneOfControl";
+import GutenbergComboboxControl, { gutenbergComboboxTester } from "../renderers/Primitive/ComboboxControl";
 import GutenbergObjectRenderer, { gutenbergObjectControlTester } from "../renderers/ObjectRenderer";
 import GutenbergArrayRenderer, { gutenbergArrayControlTester } from "../renderers/ArrayControlRenderer";
 import PortedArrayRenderer, { portedArrayControlTester } from "../renderers/PortedArrayRenderer";
@@ -97,18 +98,13 @@ const schema = {
 };
 
 const uischema = {
-  "type": "GroupLayout",
+  "type": "NavigatorLayout",
   "label": "Address",
   "elements": [
     {
       "type": "Control",
       "label": "Name",
-      "scope": "#/properties/business/properties/job"
-    },
-    {
-      "type": "Control",
-      "label": "Birth Date",
-      "scope": "#/properties/business/properties/experience"
+      "scope": "#"
     }
   ]
 }
@@ -135,6 +131,7 @@ const renderers = [
   { tester: booleanToggleControlTester, renderer: BooleanToggleControl},
   { tester: booleanCheckboxControlTester, renderer: BooleanCheckboxControl},
   { tester: gutenbergToggleGroupTester, renderer: GutenbergToggleGroupControl},
+  { tester: gutenbergComboboxTester, renderer: GutenbergComboboxControl},
   { tester: gutenbergToggleGroupOneOfTester, renderer: GutenbergToggleGroupOneOfControl},
   { tester: gutenbergObjectControlTester, renderer: GutenbergObjectRenderer},
   { tester: gutenbergArrayControlTester, renderer: GutenbergArrayRenderer},

--- a/src/js/renderers/Primitive/ComboboxControl.js
+++ b/src/js/renderers/Primitive/ComboboxControl.js
@@ -15,9 +15,10 @@ import {
     __experimentalVStack as VStack,
 	Tooltip,	
     FlexItem,
+    SelectControl
 } from '@wordpress/components';
 
-export const GutenbergToggleGroup = props => {
+export const GutenbergCombobox = props => {
 	const {
 		config,
 		id,
@@ -60,6 +61,19 @@ export const GutenbergToggleGroup = props => {
 				) }
 				</FlexItem>
 				<FlexItem>
+                <SelectControl
+                    multiple={ true }
+                    value={ data }
+                    onChange={ onChange }
+                    options={[
+                        {
+                            disabled: true,
+                            label: 'Select an Option',
+                            value: ''
+                        },
+                        ...options
+                    ]}
+                    />
 					<ToggleGroupControl 
 						value={ data }
 						isBlock
@@ -80,12 +94,12 @@ export const GutenbergToggleGroup = props => {
 	)
 }
 
-export const GutenbergToggleGroupControl = props => {
-  	return <GutenbergToggleGroup {...props} />
+export const GutenbergComboboxControl = props => {
+  	return <GutenbergCombobox {...props} />
 }
 
-export const gutenbergToggleGroupTester = rankWith(
-	9,
-	and(isEnumControl, formatIs("toggle-group"))
+export const gutenbergComboboxTester = rankWith(
+	10,
+	isEnumControl
 )
-export default withJsonFormsEnumProps(GutenbergToggleGroupControl)
+export default withJsonFormsEnumProps( GutenbergComboboxControl )

--- a/src/js/renderers/Primitive/ComboboxControl.js
+++ b/src/js/renderers/Primitive/ComboboxControl.js
@@ -15,7 +15,8 @@ import {
     __experimentalVStack as VStack,
 	Tooltip,	
     FlexItem,
-    SelectControl
+    SelectControl,
+    ComboboxControl
 } from '@wordpress/components';
 
 export const GutenbergCombobox = props => {
@@ -61,33 +62,29 @@ export const GutenbergCombobox = props => {
 				) }
 				</FlexItem>
 				<FlexItem>
-                <SelectControl
-                    multiple={ true }
-                    value={ data }
-                    onChange={ onChange }
-                    options={[
-                        {
-                            disabled: true,
-                            label: 'Select an Option',
-                            value: ''
-                        },
-                        ...options
-                    ]}
-                    />
-					<ToggleGroupControl 
-						value={ data }
-						isBlock
-						onChange={ onChange }
-					>
-						{options.map((option) => (
-							<ToggleGroupControlOption 
-								value={option.value}
-								key={option.label}
-								label={option.label}
-								disabled={!enabled}
-							/>
-						))}
-					</ToggleGroupControl>
+                    { appliedUiSchemaOptions.autocomplete === false ? (
+                        <SelectControl
+                            value={ data }
+                            onChange={ onChange }
+                            options={[
+                                {
+                                    disabled: true,
+                                    label: 'Select an Option',
+                                    value: ''
+                                },
+                                ...options
+                            ]}
+                        />
+                    ) : (
+                        <ComboboxControl
+                            value={ data }
+                            onChange={ onChange }
+                            options={[
+                                ...options
+                            ]}
+                            allowReset={ false }
+                        />
+                    ) }
 				</FlexItem>
 			</VStack>
 		</>
@@ -99,7 +96,7 @@ export const GutenbergComboboxControl = props => {
 }
 
 export const gutenbergComboboxTester = rankWith(
-	10,
+	8,
 	isEnumControl
 )
 export default withJsonFormsEnumProps( GutenbergComboboxControl )

--- a/src/js/renderers/Primitive/ToggleGroupControl.js
+++ b/src/js/renderers/Primitive/ToggleGroupControl.js
@@ -65,12 +65,12 @@ export const GutenbergToggleGroup = props => {
 						isBlock
 						onChange={ onChange }
 					>
-						{options.map((option) => (
+						{options.map( ( option ) => (
 							<ToggleGroupControlOption 
-								value={option.value}
-								key={option.label}
-								label={option.label}
-								disabled={!enabled}
+								value={ option.value }
+								key={ option.label }
+								label={ option.label }
+								disabled={ !enabled }
 							/>
 						))}
 					</ToggleGroupControl>
@@ -86,6 +86,6 @@ export const GutenbergToggleGroupControl = props => {
 
 export const gutenbergToggleGroupTester = rankWith(
 	9,
-	and(isEnumControl, formatIs("toggle-group"))
+	and( isEnumControl, formatIs( "toggle-group" ) )
 )
-export default withJsonFormsEnumProps(GutenbergToggleGroupControl)
+export default withJsonFormsEnumProps( GutenbergToggleGroupControl )

--- a/src/js/renderers/Primitive/ToggleGroupOneOfControl.js
+++ b/src/js/renderers/Primitive/ToggleGroupOneOfControl.js
@@ -66,14 +66,14 @@ export const GutenbergToggleGroupOneOf = props => {
                     isBlock
                     onChange={ onChange }
                 >
-                    {options.map((option) => (
+                    { options.map( ( option ) => (
                         <ToggleGroupControlOption 
-                            value={option.value}
-                            key={option.label}
-                            label={option.label}
-                            disabled={!enabled}
+                            value={ option.value }
+                            key={ option.label }
+                            label={ option.label }
+                            disabled={ !enabled }
                         />
-                    ))}
+                    ) ) }
                 </ToggleGroupControl>
             </FlexItem>
         </VStack>
@@ -86,7 +86,7 @@ export const GutenbergToggleGroupOneOfControl = props => {
 }
 
 export const gutenbergToggleGroupOneOfTester = rankWith(
-  21,
-  and(isOneOfEnumControl, formatIs("toggle-group"))
+  9,
+  and( isOneOfEnumControl, formatIs( "toggle-group" ) )
 )
-export default withJsonFormsOneOfEnumProps(GutenbergToggleGroupOneOfControl)
+export default withJsonFormsOneOfEnumProps( GutenbergToggleGroupOneOfControl )

--- a/src/js/renderers/layouts/GutenbergGroupLayout.js
+++ b/src/js/renderers/layouts/GutenbergGroupLayout.js
@@ -9,8 +9,6 @@ import {
 	Card,
 	CardHeader,
 	CardBody,
-	CardFooter,
-	Text,
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
   


### PR DESCRIPTION
## Summary
- Implement enum based on json schema
1. SelectControl when uischema options `autocomplete` false
<img width="1800" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/029c4e98-05e9-4c21-ad81-6d33e3e938bc">

```
{
          type: 'Control',
          scope: '#/properties/plainEnum',
          options: {
            autocomplete: false,
          },
        },
```
2. ComboboxControl by default (with text input suggestions)
<img width="1800" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/77594264-547c-43a4-a8c9-66e8d7c99029">


## Reference
https://github.com/bangank36/WP-Builder/issues/74