### PR TITLE
WP-Builder: Fix undefined array data error

### DIFF
--- a/src/js/renderers/ArrayLayoutRenderer.js
+++ b/src/js/renderers/ArrayLayoutRenderer.js
@@ -142,7 +142,7 @@ export const ArrayControl = ( {
                 isSeparated={true}
                 size="small"
             >
-                { ( data )? (
+                { ( data ) ? (
                     range( 0, data.length ).map(( index ) => {
                         return (
                             <Item key={ index }>
@@ -189,7 +189,7 @@ export const ArrayControl = ( {
 						schema={ schema }
 						label={ label } 
 						path={ path }
-						route={ `${ route }/${ data.length }` } 
+						route={ `${ route }/${ data?.length || 0 }` } 
 						addItem={ addItem }
 					/>
 				</Item>


### PR DESCRIPTION
## Summary
Check for array.length to prevent the error
- Tested against an empty array data 
- Confirm the add new item button works as expected

## Reference
https://github.com/bangank36/WP-Builder/issues/86