### PR TITLE
WP-Builder: Implement select control for oneOf enum

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -13,6 +13,7 @@ import BooleanToggleControl, { booleanToggleControlTester } from "../renderers/P
 import GutenbergToggleGroupControl, { gutenbergToggleGroupTester } from "../renderers/Primitive/ToggleGroupControl";
 import GutenbergToggleGroupOneOfControl, { gutenbergToggleGroupOneOfTester } from "../renderers/Primitive/ToggleGroupOneOfControl";
 import GutenbergComboboxControl, { gutenbergComboboxTester } from "../renderers/Primitive/ComboboxControl";
+import GutenbergComboboxOneOfControl, { gutenbergComboboxOneOfTester } from "../renderers/Primitive/ComboboxOneOfControl";
 import GutenbergObjectRenderer, { gutenbergObjectControlTester } from "../renderers/ObjectRenderer";
 import GutenbergArrayRenderer, { gutenbergArrayControlTester } from "../renderers/ArrayControlRenderer";
 import PortedArrayRenderer, { portedArrayControlTester } from "../renderers/PortedArrayRenderer";
@@ -57,12 +58,10 @@ const schema = {
         gender: {
           type: "string",
           enum: [ "male", "female", "other" ],
-          format: 'toggle-group',
           description: "The gender of the user"
         },
         race: {
           type: 'string',
-          format: 'toggle-group',
           oneOf: [
             { const: 'asian', title: 'Asian' },
             { const: 'latin', title: 'Latin' },
@@ -132,6 +131,7 @@ const renderers = [
   { tester: booleanCheckboxControlTester, renderer: BooleanCheckboxControl},
   { tester: gutenbergToggleGroupTester, renderer: GutenbergToggleGroupControl},
   { tester: gutenbergComboboxTester, renderer: GutenbergComboboxControl},
+  { tester: gutenbergComboboxOneOfTester, renderer: GutenbergComboboxOneOfControl},
   { tester: gutenbergToggleGroupOneOfTester, renderer: GutenbergToggleGroupOneOfControl},
   { tester: gutenbergObjectControlTester, renderer: GutenbergObjectRenderer},
   { tester: gutenbergArrayControlTester, renderer: GutenbergArrayRenderer},

--- a/src/js/renderers/Primitive/ComboboxOneOfControl.js
+++ b/src/js/renderers/Primitive/ComboboxOneOfControl.js
@@ -1,10 +1,10 @@
 import React from "react";
 import merge from "lodash/merge";
 import { 
-    isEnumControl, 
+    isOneOfEnumControl, 
     rankWith 
 } from "@jsonforms/core";
-import { withJsonFormsEnumProps } from "@jsonforms/react";
+import { withJsonFormsOneOfEnumProps } from "@jsonforms/react";
 
 import { isDescriptionHidden } from "@jsonforms/core";
 import {
@@ -15,7 +15,7 @@ import {
     ComboboxControl
 } from '@wordpress/components';
 
-export const GutenbergCombobox = props => {
+export const GutenbergComboboxOneOf = props => {
 	const {
 		config,
 		id,
@@ -88,11 +88,11 @@ export const GutenbergCombobox = props => {
 }
 
 export const GutenbergComboboxControl = props => {
-  	return <GutenbergCombobox {...props} />
+  	return <GutenbergComboboxOneOf {...props} />
 }
 
-export const gutenbergComboboxTester = rankWith(
+export const gutenbergComboboxOneOfTester = rankWith(
 	8,
-	isEnumControl
+	isOneOfEnumControl
 )
-export default withJsonFormsEnumProps( GutenbergComboboxControl )
+export default withJsonFormsOneOfEnumProps( GutenbergComboboxControl )


### PR DESCRIPTION
## Summary
- Implement select control renderer for oneOf enum using `withJsonFormsOneOfEnumProps` HOC

## Reference
https://github.com/bangank36/WP-Builder/issues/88
#84 