### PR TITLE
WP-Builder: Implement array of enum values

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -16,6 +16,7 @@ import GutenbergComboboxControl, { gutenbergComboboxTester } from "../renderers/
 import GutenbergComboboxOneOfControl, { gutenbergComboboxOneOfTester } from "../renderers/Primitive/ComboboxOneOfControl";
 import GutenbergObjectRenderer, { gutenbergObjectControlTester } from "../renderers/ObjectRenderer";
 import GutenbergArrayRenderer, { gutenbergArrayControlTester } from "../renderers/ArrayControlRenderer";
+import GutenbergEnumArrayRenderer, { gutenbergEnumArrayRendererTester } from "../renderers/MultiEnumArrayControl";
 import PortedArrayRenderer, { portedArrayControlTester } from "../renderers/PortedArrayRenderer";
 import GutenbergNavigatorlLayoutRenderer, { gutenbergNavigatorLayoutTester } from "../renderers/NavigatorLayout";
 import GutenbergVerticalLayoutRenderer, { gutenbergVerticalLayoutTester } from "../renderers/layouts/GutenbergVerticalLayout";
@@ -135,6 +136,7 @@ const renderers = [
   { tester: gutenbergToggleGroupOneOfTester, renderer: GutenbergToggleGroupOneOfControl},
   { tester: gutenbergObjectControlTester, renderer: GutenbergObjectRenderer},
   { tester: gutenbergArrayControlTester, renderer: GutenbergArrayRenderer},
+  { tester: gutenbergEnumArrayRendererTester, renderer: GutenbergEnumArrayRenderer},
   // { tester: portedArrayControlTester, renderer: PortedArrayRenderer},
   { tester: gutenbergNavigatorLayoutTester, renderer: GutenbergNavigatorlLayoutRenderer},
   { tester: gutenbergVerticalLayoutTester, renderer: GutenbergVerticalLayoutRenderer},

--- a/src/js/renderers/MultiEnumArrayControl.js
+++ b/src/js/renderers/MultiEnumArrayControl.js
@@ -1,0 +1,115 @@
+import {
+	and,
+	hasType,
+	rankWith,
+	schemaMatches,
+	schemaSubPathMatches,
+	uiTypeIs
+} from "@jsonforms/core";
+  
+import { withJsonFormsMultiEnumProps } from "@jsonforms/react";
+import xorBy from "lodash/xorBy";
+import React from "react";
+
+import { 
+	FormTokenField,
+	__experimentalVStack as VStack,
+	Tooltip,	
+    FlexItem,
+} from '@wordpress/components';
+
+import styled from '@emotion/styled';
+
+export const GutenbergEnumArrayRenderer = ( {
+	schema,
+	visible,
+	errors,
+	path,
+	options,
+	data,
+	addItem,
+	removeItem,
+	handleChange: _handleChange,
+	description,
+	id,
+	label
+} ) => {
+
+	const HiddenLabelFormTokenFieldWrapper = styled( FlexItem )`
+		.components-form-token-field__label {
+			display: none;
+		}
+	`;
+
+	return !visible ? null : (
+		<>
+			<VStack justify="space-between">
+				<FlexItem>
+				{ description ? (
+					<Tooltip text={ description }>
+					<label htmlFor={ id }>
+						{ label }
+					</label>
+				</Tooltip>
+				) : ( 
+					<label htmlFor={ id }>
+						{ label }
+					</label> 
+				) }
+				</FlexItem>
+				<HiddenLabelFormTokenFieldWrapper>
+					<FormTokenField
+						onChange={ ( tokens ) => {
+							// Get distinct value between tokens and data (both ways) and check wether the value is belong to data or not, of yes, then use addItem, otherwise, use removeItem
+							const distinctTokens = xorBy( tokens, data );
+							if ( distinctTokens.length > 0 ) {
+								const value = distinctTokens[ 0 ];
+								if ( data.includes( value ) ) {
+									removeItem( path, value );
+								} else {
+									addItem( path, value );
+								}
+							}
+						} }
+						suggestions={ options.map( ( option ) => option.value ) }
+						value={ data }
+						__experimentalShowHowTo={ false }
+						__nextHasNoMarginBottom={ true }
+						__experimentalExpandOnFocus={ true }
+					/>
+				</HiddenLabelFormTokenFieldWrapper>
+			</VStack>
+		</>
+	)
+}
+
+const hasOneOfItems = schema =>
+	schema.oneOf !== undefined &&
+	schema.oneOf.length > 0 &&
+	schema.oneOf.every(entry => {
+		return entry.const !== undefined
+	})
+
+const hasEnumItems = schema =>
+	schema.type === "string" && schema.enum !== undefined
+
+export const gutenbergEnumArrayRendererTester = rankWith(
+	10,
+	and(
+		uiTypeIs( "Control" ),
+		and(
+			schemaMatches(
+				schema =>
+				hasType( schema, "array" ) &&
+				!Array.isArray( schema.items ) &&
+				schema.uniqueItems === true
+			),
+			schemaSubPathMatches( "items", schema => {
+				return hasOneOfItems( schema ) || hasEnumItems( schema )
+			} )
+		)
+	)
+)
+
+export default withJsonFormsMultiEnumProps( GutenbergEnumArrayRenderer )
+  

--- a/src/js/renderers/MultiEnumArrayControl.js
+++ b/src/js/renderers/MultiEnumArrayControl.js
@@ -112,4 +112,3 @@ export const gutenbergEnumArrayRendererTester = rankWith(
 )
 
 export default withJsonFormsMultiEnumProps( GutenbergEnumArrayRenderer )
-  


### PR DESCRIPTION
## Summary
- Implement the array enum control using FormTokenField
- Both enum and oneOf enum supported
- So far the control only support the `value` of the data, the `label` is ignored
<img width="345" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/1b91fbf7-92a6-4610-a3a1-01591cdff99d">


## Reference
https://github.com/bangank36/WP-Builder/issues/90
Example schema can be found here [in example](https://github.com/eclipsesource/jsonforms/blob/e80a87330490b181a8e5ac9edfd47980bab9fecc/packages/examples/src/examples/enum-multi.ts#L32)