### PR TITLE
WP-Builder: Introduce new control for text transform

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -5,6 +5,7 @@ import {
 } from "@jsonforms/vanilla-renderers";
 import { JsonForms } from "@jsonforms/react";
 import TextControl, { textControlTester } from "../renderers/Primitive/TextControl";
+import TextTranformControl, { textTransformControlTester } from "../renderers/Primitive/TextTransformControl";
 import DatepickerControl, { datepickerControlTester } from "../renderers/Primitive/DatepickerControl";
 import MultilineTextControl, { multilineTextControlTester } from "../renderers/Primitive/MultilineTextControl";
 import ColorPaletteTextControl, { colorPaletteControlTester } from "../renderers/Primitive/ColorPaletteControl";
@@ -125,6 +126,7 @@ const renderers = [
   ...materialRenderers,
   //register custom renderers
   { tester: textControlTester, renderer: TextControl },
+  { tester: textTransformControlTester, renderer: TextTranformControl },
   { tester: datepickerControlTester, renderer: DatepickerControl },
   { tester: multilineTextControlTester, renderer: MultilineTextControl },
   { tester: colorPaletteControlTester, renderer: ColorPaletteTextControl },

--- a/src/js/renderers/Primitive/ColorPaletteControl.js
+++ b/src/js/renderers/Primitive/ColorPaletteControl.js
@@ -120,7 +120,7 @@ const TextControl = (props) => {
 
 export const colorPaletteControlTester = rankWith(
   6, //increase rank as needed
-  and(isStringControl,or(formatIs('color'), optionIs('format', 'color')))
+  and( isStringControl, or( formatIs( 'color' ), optionIs( 'format', 'color' ) ) )
 );
 
 export default withJsonFormsControlProps(TextControl);

--- a/src/js/renderers/Primitive/TextTransformControl.js
+++ b/src/js/renderers/Primitive/TextTransformControl.js
@@ -1,0 +1,67 @@
+import React from "react";
+import { withJsonFormsControlProps } from "@jsonforms/react";
+import { 
+    rankWith, 
+    isStringControl,
+    and,
+    optionIs
+} from "@jsonforms/core";
+import { 
+    __experimentalVStack as VStack,
+	Tooltip,	
+    FlexItem
+} from '@wordpress/components';
+import { __experimentalTextTransformControl as TextTransformControl } from '@wordpress/block-editor'; 
+import styled from '@emotion/styled';
+
+    const HiddenLabelFormTokenFieldWrapper = styled( FlexItem )`
+		legend {
+			display: none;
+		}
+	`;
+
+const TextControl = ( props ) => {
+	const {
+		id,
+		description,
+		label,
+		path,
+		data,
+		handleChange
+	} = props;
+  
+	return ( 
+		<>
+			<VStack justify="space-between">
+				<FlexItem>
+					{ description ? (
+						<Tooltip text={ description }>
+						<label htmlFor={ id }>
+							{ label }
+						</label>
+					</Tooltip>
+					) : ( 
+						<label htmlFor={ id }>
+							{ label }
+						</label> 
+					) }
+				</FlexItem>
+				<HiddenLabelFormTokenFieldWrapper>
+					<TextTransformControl
+                        value={ data || '' }
+						onChange={ ( value ) =>
+							handleChange( path, value === '' ? undefined : value )
+						}
+                    /> 
+				</HiddenLabelFormTokenFieldWrapper>
+			</VStack>
+		</>
+	)
+};
+
+export const textTransformControlTester = rankWith(
+	5, //increase rank as needed
+	and( isStringControl, optionIs( 'format', 'text-transform' ) )
+);
+
+export default withJsonFormsControlProps( TextControl );


### PR DESCRIPTION
## Summary
- TextTransform control is a `string` control and can only be triggered using the uischema `format`

<img width="264" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/c45bd7f7-ab2d-4cd6-a379-674ee19c43da">

```
{
      "type": "Control",
      "label": "Name",
      "scope": "#/properties/props/properties/text_transform",
      "options": {
        "format": "text-transform"
      }
    }
```

## Reference
https://github.com/bangank36/WP-Builder/issues/12