### PR TITLE
WP-Builder: Implement integer control

### DIFF
--- a/src/js/component/form.jsx
+++ b/src/js/component/form.jsx
@@ -5,6 +5,7 @@ import {
 } from "@jsonforms/vanilla-renderers";
 import { JsonForms } from "@jsonforms/react";
 import TextControl, { textControlTester } from "../renderers/Primitive/TextControl";
+import IntegerControl, { integerControlTester } from "../renderers/Primitive/IntegerControl";
 import TextTranformControl, { textTransformControlTester } from "../renderers/Primitive/TextTransformControl";
 import DatepickerControl, { datepickerControlTester } from "../renderers/Primitive/DatepickerControl";
 import MultilineTextControl, { multilineTextControlTester } from "../renderers/Primitive/MultilineTextControl";
@@ -126,6 +127,7 @@ const renderers = [
   ...materialRenderers,
   //register custom renderers
   { tester: textControlTester, renderer: TextControl },
+  { tester: integerControlTester, renderer: IntegerControl },
   { tester: textTransformControlTester, renderer: TextTranformControl },
   { tester: datepickerControlTester, renderer: DatepickerControl },
   { tester: multilineTextControlTester, renderer: MultilineTextControl },

--- a/src/js/renderers/Primitive/IntegerControl.js
+++ b/src/js/renderers/Primitive/IntegerControl.js
@@ -1,0 +1,60 @@
+import React from "react";
+import { withJsonFormsControlProps } from "@jsonforms/react";
+import { rankWith, isIntegerControl } from "@jsonforms/core";
+import { 
+    __experimentalNumberControl as NumberControl,
+    __experimentalVStack as VStack,
+	Tooltip,	
+    FlexItem
+} from '@wordpress/components';
+
+const IntegerControl = ( props ) => {
+	const {
+		id,
+		description,
+		label,
+		path,
+		data,
+        schema,
+		handleChange
+	} = props;
+  
+	return ( 
+		<>
+			<VStack justify="space-between">
+				<FlexItem>
+					{ description ? (
+						<Tooltip text={ description }>
+						<label htmlFor={ id }>
+							{ label }
+						</label>
+					</Tooltip>
+					) : ( 
+						<label htmlFor={ id }>
+							{ label }
+						</label> 
+					) }
+				</FlexItem>
+				<FlexItem>
+					<NumberControl
+						value={ Number(data || schema.default) }
+						onChange={ ( value ) =>
+							handleChange( path, value === '' ? undefined : value )
+						}
+                        spinControls={ "custom" }
+                        min={ schema.minimum }
+                        max={ schema.maximum }
+                        step={ schema.multipleOf || 1 }
+					/> 
+				</FlexItem>
+			</VStack>
+		</>
+	)
+};
+
+export const integerControlTester = rankWith(
+	4, //increase rank as needed
+	isIntegerControl
+);
+
+export default withJsonFormsControlProps( IntegerControl );


### PR DESCRIPTION
## Summary
- Implement `integer` control using Gutenberg Number Control
- Schema example, more on[ number validation ](https://github.com/eclipsesource/jsonforms/blob/e80a87330490b181a8e5ac9edfd47980bab9fecc/packages/core/src/models/jsonSchema4.ts#L58C3-L58C3)
```
houseNumber: { 
          type: 'integer',
          maximum: 100,
          minimum: 1,
          default: 50,
          multipleOf: 3
       },
```
<img width="365" alt="image" src="https://github.com/bangank36/WP-Builder/assets/10071857/62d4f296-d266-4780-926c-8cfea5b07a73">

## Reference

https://github.com/bangank36/WP-Builder/issues/93