### PR TITLE
WP Builder: Add TableLayout option for array rendering

### DIFF
--- a/src/js/renderers/ArrayLayoutRenderer.js
+++ b/src/js/renderers/ArrayLayoutRenderer.js
@@ -1,7 +1,6 @@
 import range from "lodash/range"
 import React from 'react';
 import {
-	createDefaultValue,
 	Helpers
 } from "@jsonforms/core";
 import {
@@ -9,16 +8,7 @@ import {
 } from "@jsonforms/react";
 import { resolvePathToRoute } from './util';
 
-import { 
-	plus,
-	moreVertical, 
-	edit, 
-	copy, 
-	trash,
-	chevronUp,
-	chevronDown,
-	dragHandle
-} from '@wordpress/icons';
+import { dragHandle } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { IconWithCurrentColor } from './NavigatorLayout/icon-with-current-color';
 import { NavigationButtonAsItem } from './NavigatorLayout/navigation-button';
@@ -26,98 +16,17 @@ import { NavigationButtonAsItem } from './NavigatorLayout/navigation-button';
 import {
 	__experimentalUseNavigator as useNavigator,
 	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
     __experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
-	DropdownMenu, 
-	MenuGroup, 
-	MenuItem,
 	FlexItem,
-	Button
 } from '@wordpress/components';
 
-const ItemActionsMenu = ( { onEdit, onDuplicate, onRemove } ) => (
-    <DropdownMenu icon={ moreVertical } label="Select an action">
-        { () => (
-            <>
-                <MenuGroup>
-                    <MenuItem icon={ edit } onClick={ onEdit }>
-                        Edit
-                    </MenuItem>
-                    <MenuItem icon={ copy } onClick={ onDuplicate }>
-                        Duplicate
-                    </MenuItem>
-                </MenuGroup>
-                <MenuGroup>
-                    <MenuItem icon={ trash } onClick={ onRemove }>
-                        Remove
-                    </MenuItem>
-                </MenuGroup>
-            </>
-        ) }
-    </DropdownMenu>
-);
-
-const ItemMovers = ( { moveUpEnable, onMoveUp, moveDownEnable, onMoveDown } ) => {
-	return (
-		<VStack
-			style={ {
-				gap: 0
-			} }
-		>
-			<Button
-				style={ { 
-					height: '12px',
-					boxSizing: 'border-box',
-					padding: '6px 12px'
-				} }
-				size={ 'small' }
-				icon={ chevronUp }
-				aria-label={ `Move item up` }
-				onClick={ onMoveUp }
-				disabled={ ! moveUpEnable }
-			>
-			</Button>
-			<Button
-				style={ { 
-					height: '12px',
-					boxSizing: 'border-box',
-					padding: '6px 12px'
-				} }
-				size={ 'small' }
-				icon={ chevronDown }
-				aria-label={ `Move item down` }
-				onClick={ onMoveDown }
-				disabled={ ! moveDownEnable }
-			>
-			</Button>	
-		</VStack>
-	);
-}
-
-const AddItemButton = ({ route, path, label, schema, addItem }) => {
-	const navigator = useNavigator();
-	
-	return (
-		<Button
-			aria-label={ `Add new item` }
-			onClick={ () => {
-				addItem( path, createDefaultValue(schema) )();
-				navigator.goTo( route );
-			} }
-		>
-			<HStack 
-				justify="center"
-			>
-			<FlexItem>
-				<IconWithCurrentColor
-					icon={ plus }
-				/>Add { label }
-			</FlexItem>
-			</HStack>
-		</Button>
-	);
-}
+// Import shared components
+import { 
+	ItemMovers, 
+	ItemActionsMenu, 
+	AddItemButton,
+} from './array-utils';
 
 export const ArrayControl = ( {
 	classNames,
@@ -193,8 +102,8 @@ export const ArrayControl = ( {
 						schema={ schema }
 						label={ label } 
 						path={ path }
-						route={ `${ route }/${ data?.length || 0 }` } 
 						addItem={ addItem }
+						onClick={ () => navigator.goTo( `${ route }/${ data?.length || 0 }` ) }
 					/>
 				</Item>
             </ItemGroup>

--- a/src/js/renderers/ArrayTableRenderer.js
+++ b/src/js/renderers/ArrayTableRenderer.js
@@ -1,0 +1,153 @@
+import range from "lodash/range";
+import React, { useMemo } from 'react';
+import {
+    composePaths,
+} from "@jsonforms/core";
+import {
+    JsonFormsDispatch
+} from "@jsonforms/react";
+
+import { 
+    dragHandle,
+} from '@wordpress/icons';
+
+import {
+    __experimentalHStack as HStack,
+    __experimentalItemGroup as ItemGroup,
+    __experimentalItem as Item,
+    FlexItem,
+} from '@wordpress/components';
+
+// Import shared components
+import { 
+    ItemMovers, 
+    ItemActionsMenu, 
+    AddItemButton,
+    DragHandleIcon 
+} from './array-utils';
+
+/**
+ * ArrayTableControl - Renders an object array with inline controls
+ * 
+ * Styled to match the inline layout (ItemGroup/Item) but with controls
+ * rendered directly instead of navigation buttons.
+ * 
+ * Each row contains:
+ * - Move up/down buttons (or drag handle if draggable)
+ * - The control for the item (rendered via JsonFormsDispatch)
+ * - Actions menu (Duplicate, Remove)
+ */
+export const ArrayTableControl = ({
+    data,
+    label,
+    path,
+    schema,
+    errors,
+    addItem,
+    removeItems,
+    moveUp,
+    moveDown,
+    renderers,
+    cells,
+    rootSchema,
+    draggable = false,
+}) => {
+    // Generate a layout UI schema for items based on schema properties
+    // For objects with properties, create HorizontalLayout with controls
+    // For objects with format (like daterange), use simple Control
+    const itemUiSchema = useMemo(() => {
+        if (schema.format) {
+            // Has a format - use Control which will dispatch to format-specific renderer
+            return {
+                type: 'Control',
+                scope: '#'
+            };
+        }
+        
+        if (schema.properties) {
+            // Has properties - generate HorizontalLayout with controls for each property
+            const elements = Object.keys(schema.properties).map((propKey) => ({
+                type: 'Control',
+                scope: `#/properties/${propKey}`,
+                label: schema.properties[propKey].title || propKey
+            }));
+            
+            return {
+                type: 'HorizontalLayout',
+                elements
+            };
+        }
+        
+        // Fallback to simple control
+        return {
+            type: 'Control',
+            scope: '#'
+        };
+    }, [schema]);
+
+    return (
+        <div>
+            <div>{errors}</div>
+            <ItemGroup 
+                isBordered={false} 
+                isSeparated={true}
+                size="small"
+            >
+                {data ? (
+                    range(0, data.length).map((index) => {
+                        const childPath = composePaths(path, `${index}`);
+                        
+                        return (
+                            <Item key={index}>
+                                <HStack justify="space-between">
+                                    <FlexItem>
+                                        { draggable ? <DragHandleIcon /> : <ItemMovers
+                                            moveUpEnable={index > 0}
+                                            onMoveUp={() => moveUp(path, index)()}
+                                            moveDownEnable={index < data.length - 1}
+                                            onMoveDown={() => moveDown(path, index)()}
+                                        />}
+                                    </FlexItem>
+                                    <FlexItem style={{ flex: 1 }}>
+                                        <JsonFormsDispatch
+                                            schema={schema}
+                                            uischema={itemUiSchema}
+                                            path={childPath}
+                                            renderers={renderers}
+                                            cells={cells}
+                                        />
+                                    </FlexItem>
+                                    <ItemActionsMenu 
+                                        showEdit={false}
+                                        onRemove={() => {
+                                            if (
+                                                window.confirm(
+                                                    "Are you sure you wish to delete this item?"
+                                                )
+                                            ) {
+                                                removeItems(path, [index])();
+                                            }
+                                        }}
+                                        onDuplicate={() => {
+                                            addItem(path, data[index])();
+                                        }}
+                                    />
+                                </HStack>
+                            </Item>
+                        );
+                    })
+                ) : null}
+                <Item>
+                    <AddItemButton 
+                        schema={schema}
+                        label={label} 
+                        path={path}
+                        addItem={addItem}
+                    />
+                </Item>
+            </ItemGroup>
+        </div>
+    );
+};
+
+export default ArrayTableControl;

--- a/src/js/renderers/array-utils.js
+++ b/src/js/renderers/array-utils.js
@@ -1,0 +1,127 @@
+import range from "lodash/range";
+import React from 'react';
+import {
+    createDefaultValue,
+} from "@jsonforms/core";
+
+import { 
+    plus,
+    moreVertical,
+    edit,
+    copy,
+    trash,
+    chevronUp,
+    chevronDown,
+    dragHandle,
+} from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import { IconWithCurrentColor } from './NavigatorLayout/icon-with-current-color';
+
+import {
+    __experimentalHStack as HStack,
+    __experimentalVStack as VStack,
+    DropdownMenu, 
+    MenuGroup, 
+    MenuItem,
+    FlexItem,
+    Button
+} from '@wordpress/components';
+
+/**
+ * Move buttons component for reordering rows
+ */
+export const ItemMovers = ({ moveUpEnable, onMoveUp, moveDownEnable, onMoveDown }) => {
+    return (
+        <VStack
+            style={{
+                gap: 0
+            }}
+        >
+            <Button
+                style={{ 
+                    height: '12px',
+                    boxSizing: 'border-box',
+                    padding: '6px 12px'
+                }}
+                size="small"
+                icon={chevronUp}
+                aria-label="Move item up"
+                onClick={onMoveUp}
+                disabled={!moveUpEnable}
+            />
+            <Button
+                style={{ 
+                    height: '12px',
+                    boxSizing: 'border-box',
+                    padding: '6px 12px'
+                }}
+                size="small"
+                icon={chevronDown}
+                aria-label="Move item down"
+                onClick={onMoveDown}
+                disabled={!moveDownEnable}
+            />
+        </VStack>
+    );
+};
+
+/**
+ * Actions menu for array items
+ * @param {boolean} showEdit - Whether to show Edit option
+ */
+export const ItemActionsMenu = ({ onEdit, onDuplicate, onRemove, showEdit = true }) => (
+    <DropdownMenu icon={moreVertical} label="Select an action">
+        {() => (
+            <>
+                <MenuGroup>
+                    {showEdit && (
+                        <MenuItem icon={edit} onClick={onEdit}>
+                            Edit
+                        </MenuItem>
+                    )}
+                    <MenuItem icon={copy} onClick={onDuplicate}>
+                        Duplicate
+                    </MenuItem>
+                </MenuGroup>
+                <MenuGroup>
+                    <MenuItem icon={trash} onClick={onRemove}>
+                        Remove
+                    </MenuItem>
+                </MenuGroup>
+            </>
+        )}
+    </DropdownMenu>
+);
+
+/**
+ * Add item button for arrays
+ */
+export const AddItemButton = ({ path, label, schema, addItem, onClick }) => {
+    return (
+        <Button
+            aria-label={`Add new item`}
+            onClick={() => {
+                addItem(path, createDefaultValue(schema))();
+                if (onClick) onClick();
+            }}
+        >
+            <HStack justify="center">
+                <FlexItem>
+                    <IconWithCurrentColor
+                        icon={plus}
+                    />Add {label}
+                </FlexItem>
+            </HStack>
+        </Button>
+    );
+};
+
+/**
+ * Drag handle icon component
+ */
+export const DragHandleIcon = () => (
+    <IconWithCurrentColor icon={dragHandle} />
+);
+
+// Re-export icons for convenience
+export { dragHandle, plus, moreVertical, edit, copy, trash, chevronUp, chevronDown };


### PR DESCRIPTION
## Summary
Adds a new TableLayout option for array controls that renders item controls inline instead of navigating to a separate screen.

- Usage
```
{
  "type": "Control",
  "scope": "#/properties/myArray",
  "options": {
    "detail": {
      "type": "TableLayout",
      "draggable": true
    }
  }
}
```

<img width="952" height="126" alt="image" src="https://github.com/user-attachments/assets/2d460abf-b23c-403f-9790-0dce3088478a" />

- Features
Renders controls inline (no navigation)
Auto-generates HorizontalLayout for objects with multiple properties

## Reference
#32 #118 